### PR TITLE
Hotfix for uploading media files

### DIFF
--- a/HiP-DataStore.Model/ContentStatus.cs
+++ b/HiP-DataStore.Model/ContentStatus.cs
@@ -19,11 +19,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model
         /// <summary>
         /// The content needs to be reviewed.
         /// </summary>
-        /// <remarks>
-        /// [EnumMember(...)] only applies to JSON responses, not to requests.
-        /// That's why 
-        /// </remarks>
         [EnumMember(Value = "IN_REVIEW")]
+        // ReSharper disable once InconsistentNaming
         In_Review,
 
         /// <summary>

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -156,7 +156,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                         
                     case MediaFileUpdated e:
                         var fileDocBson = e.ToBsonDocument();
-                        fileDocBson.Remove("Id");
+                        fileDocBson.Remove("_id");
                         var bsonDoc = new BsonDocument("$set", fileDocBson);
                         _db.GetCollection<MediaElement>(ResourceType.Media.Name).UpdateOne(x => x.Id == e.Id, bsonDoc);
                         break;


### PR DESCRIPTION
This should fix an issue with file uploads.

Without this fix, `PUT /Api/Media/{id}/File` fails with the following message:
"CacheDatabaseManager could not process an event: MongoDB.Driver.MongoWriteException: A write operation resulted in an error. Mod on _id not allowed"