### PR TITLE
Updated MongoDB version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM microsoft/dotnet:1.1.1-sdk
 
-RUN apt-get update && apt-get install mongodb -y
+RUN apt-get update && apt-get install make gcc -y
+
+RUN wget https://www.openssl.org/source/openssl-1.1.0f.tar.gz && tar xzf openssl-1.1.0f.tar.gz && cd openssl-1.1.0f && ./config && make && make install
+
+RUN wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian81-3.4.4.tgz && tar xzf mongodb-linux-x86_64-debian81-3.4.4.tgz
 
 RUN mkdir -p /data/db
 

--- a/HiP-DataStore/run.sh
+++ b/HiP-DataStore/run.sh
@@ -1,3 +1,3 @@
-mongod --noprealloc &
+/mongodb-linux-x86_64-debian81-3.4.4/bin/mongod --noprealloc &
 sleep 5
 dotnet run


### PR DESCRIPTION
The Dockerfile now no longer uses the mongodb version from the apt repos, but fetches a current version from the official website.

The run-script has been modified to invoke the proper mongod.