### PR TITLE
Fixed: ExhibitId property was missing in ExhibitPageUpdated

### DIFF
--- a/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
@@ -7,6 +7,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
     {
         public int Id { get; set; }
 
+        public int ExhibitId { get; set; }
+
         public ExhibitPageArgs Properties { get; set; }
 
         public DateTimeOffset Timestamp { get; set; }

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -96,6 +96,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                         var updatedPage = new ExhibitPage(e.Properties)
                         {
                             Id = e.Id,
+                            Exhibit = { Id = e.ExhibitId },
                             Timestamp = e.Timestamp
                         };
 

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -123,6 +123,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
             var ev = new ExhibitPageUpdated
             {
                 Id = pageId,
+                ExhibitId = exhibitId,
                 Properties = args,
                 Timestamp = DateTimeOffset.Now
             };


### PR DESCRIPTION
This is potentially a breaking change: All exhibit pages that have ever been updated via a PUT call will be assigned to the exhibit with ID 0. However, in our development environment we currently have only one ExhibitPageUpdated event which updates a page belonging to exhibit 0, so in this case there's no problem.