### PR TITLE
Event versioning + bug fixes

### DIFF
--- a/HiP-DataStore.Model/Entity/ExhibitPage.cs
+++ b/HiP-DataStore.Model/Entity/ExhibitPage.cs
@@ -1,6 +1,7 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
@@ -35,8 +36,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
             new DocRef<MediaElement>(ResourceType.Media.Name);
 
         [BsonElement]
-        public DocRefList<MediaElement> Images { get; private set; } =
-            new DocRefList<MediaElement>(ResourceType.Media.Name);
+        public List<SliderPageImage> Images { get; private set; }
 
         public bool HideYearNumbers { get; set; }
 
@@ -48,7 +48,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
         {
         }
 
-        public ExhibitPage(ExhibitPageArgs args)
+        public ExhibitPage(ExhibitPageArgs2 args)
         {
             Type = args.Type;
             Title = args.Title;
@@ -57,7 +57,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
             FontFamily = args.FontFamily;
             Audio.Id = args.Audio;
             Image.Id = args.Image;
-            Images.Add(args.Images?.Select(id => (BsonValue)id));
+            Images = args.Images?.Select(img => new SliderPageImage(img)).ToList();
             HideYearNumbers = args.HideYearNumbers ?? false;
             AdditionalInformationPages.Add(args.AdditionalInformationPages?.Select(id => (BsonValue)id));
             Status = args.Status;

--- a/HiP-DataStore.Model/Entity/SliderPageImage.cs
+++ b/HiP-DataStore.Model/Entity/SliderPageImage.cs
@@ -1,0 +1,22 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
+{
+    public class SliderPageImage
+    {
+        public int Date { get; set; }
+
+        public DocRef<MediaElement> Image { get; set; } =
+            new DocRef<MediaElement>(ResourceType.Media.Name);
+
+        public SliderPageImage()
+        {
+        }
+
+        public SliderPageImage(SliderPageImageArgs args)
+        {
+            Date = args.Date;
+            Image.Id = args.Image;
+        }
+    }
+}

--- a/HiP-DataStore.Model/Events/ExhibitPageCreated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageCreated.cs
@@ -3,7 +3,22 @@ using System;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
-    public class ExhibitPageCreated : ICreateEvent
+    public class ExhibitPageCreated2 : ICreateEvent
+    {
+        public int Id { get; set; }
+
+        public int ExhibitId { get; set; }
+
+        public ExhibitPageArgs2 Properties { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+        public ResourceType GetEntityType() => ResourceType.ExhibitPage;
+
+        public ContentStatus GetStatus() => Properties.Status;
+    }
+
+    public class ExhibitPageCreated : ICreateEvent, IMigratable<ExhibitPageCreated2>
     {
         public int Id { get; set; }
 
@@ -16,5 +31,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
         public ResourceType GetEntityType() => ResourceType.ExhibitPage;
 
         public ContentStatus GetStatus() => Properties.Status;
+
+        public ExhibitPageCreated2 Migrate() => new ExhibitPageCreated2
+        {
+            Id = Id,
+            ExhibitId = ExhibitId,
+            Timestamp = Timestamp,
+            Properties = Properties.Migrate()
+        };
     }
 }

--- a/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
@@ -3,9 +3,26 @@ using System;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
-    public class ExhibitPageUpdated : IUpdateEvent
+    public class ExhibitPageUpdated2 : IUpdateEvent
     {
         public int Id { get; set; }
+
+        public int ExhibitId { get; set; }
+
+        public ExhibitPageArgs2 Properties { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+        public ResourceType GetEntityType() => ResourceType.ExhibitPage;
+
+        public ContentStatus GetStatus() => Properties.Status;
+    }
+
+    public class ExhibitPageUpdated : IUpdateEvent, IMigratable<ExhibitPageUpdated2>
+    {
+        public int Id { get; set; }
+
+        public int ExhibitId { get; set; }
 
         public ExhibitPageArgs Properties { get; set; }
 
@@ -14,5 +31,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
         public ResourceType GetEntityType() => ResourceType.ExhibitPage;
 
         public ContentStatus GetStatus() => Properties.Status;
+
+        public ExhibitPageUpdated2 Migrate() => new ExhibitPageUpdated2
+        {
+            Id = Id,
+            ExhibitId = ExhibitId,
+            Timestamp = Timestamp,
+            Properties = Properties.Migrate()
+        };
     }
 }

--- a/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
@@ -7,6 +7,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
     {
         public int Id { get; set; }
 
+        public int ExhibitId { get; set; }
+
         public ExhibitPageArgs Properties { get; set; }
 
         public DateTimeOffset Timestamp { get; set; }

--- a/HiP-DataStore.Model/Events/IMigratable.cs
+++ b/HiP-DataStore.Model/Events/IMigratable.cs
@@ -1,0 +1,15 @@
+﻿namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
+{
+    /// <summary>
+    /// Types implementing this interface can migrate objects to a newer version of the type.
+    /// This is used for example to transform old events from the event log to the latest version.
+    /// </summary>
+    public interface IMigratable<out T>
+    {
+        /// <summary>
+        /// Transforms this object to an object of a newer version of the (logically) same type.
+        /// </summary>
+        /// <returns></returns>
+        T Migrate();
+    }
+}

--- a/HiP-DataStore.Model/Events/IMigratable.cs
+++ b/HiP-DataStore.Model/Events/IMigratable.cs
@@ -12,4 +12,20 @@
         /// <returns></returns>
         T Migrate();
     }
+
+    public static class MigratableExtensions
+    {
+        /// <summary>
+        /// Applies all possible migrations in order to update an object to the latest version of its type.
+        /// If the specified object does not support migration, it is returned as is.
+        /// </summary>
+        /// <typeparam name="TBase">The base class or interface all versions of the type have in common</typeparam>
+        public static TBase MigrateToLatestVersion<TBase>(this TBase obj)
+        {
+            while (obj is IMigratable<TBase> o)
+                obj = o.Migrate();
+
+            return obj;
+        }
+    }
 }

--- a/HiP-DataStore.Model/Rest/ExhibitPageArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageArgs.cs
@@ -1,9 +1,39 @@
-﻿using System.Collections.Generic;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 {
-    public class ExhibitPageArgs
+    // Version info: 'Images' now stores not just a list of IDs, but a list of pairs (Date, Image ID)
+    public class ExhibitPageArgs2
+    {
+        [Required]
+        public PageType Type { get; set; }
+
+        public string Title { get; set; }
+
+        [Required]
+        public string Text { get; set; }
+
+        public string Description { get; set; }
+
+        public string FontFamily { get; set; }
+
+        public int? Audio { get; set; }
+
+        public int? Image { get; set; }
+
+        public IReadOnlyCollection<SliderPageImageArgs> Images { get; set; }
+
+        public bool? HideYearNumbers { get; set; }
+
+        public IReadOnlyCollection<int> AdditionalInformationPages { get; set; }
+
+        public ContentStatus Status { get; set; }
+    }
+
+    public class ExhibitPageArgs : IMigratable<ExhibitPageArgs2>
     {
         [Required]
         public PageType Type { get; set; }
@@ -28,5 +58,27 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
         public IReadOnlyCollection<int> AdditionalInformationPages { get; set; }
 
         public ContentStatus Status { get; set; }
+
+        public ExhibitPageArgs2 Migrate() => new ExhibitPageArgs2
+        {
+            // for migration of the 'Images' property, we have to choose an arbitrary default date
+            Images = Images?.Select(imageId => new SliderPageImageArgs
+            {
+                Date = 2017,
+                Image = imageId
+            }).ToList(),
+
+            // the other properties are just copied over
+            Type = Type,
+            Title = Title,
+            Text = Text,
+            Description = Description,
+            FontFamily = FontFamily,
+            Audio = Audio,
+            Image = Image,
+            HideYearNumbers = HideYearNumbers,
+            AdditionalInformationPages = AdditionalInformationPages,
+            Status = Status
+        };
     }
 }

--- a/HiP-DataStore.Model/Rest/ExhibitPageResult.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageResult.cs
@@ -54,7 +54,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             FontFamily = page.FontFamily;
             Audio = (int?)page.Audio.Id;
             Image = (int?)page.Image.Id;
-            Images = page.Images.Select(img => new SliderPageImageResult(img)).ToList();
+            Images = page.Images?.Select(img => new SliderPageImageResult(img)).ToArray() ?? Array.Empty<SliderPageImageResult>();
             HideYearNumbers = page.HideYearNumbers;
             AdditionalInformationPages = page.AdditionalInformationPages.Select(id => (int)id).ToList();
             Status = page.Status;

--- a/HiP-DataStore.Model/Rest/ExhibitPageResult.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageResult.cs
@@ -28,7 +28,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 
         public int? Image { get; set; }
 
-        public IReadOnlyCollection<int> Images { get; set; }
+        public IReadOnlyCollection<SliderPageImageResult> Images { get; set; }
 
         public bool HideYearNumbers { get; set; }
 
@@ -54,7 +54,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             FontFamily = page.FontFamily;
             Audio = (int?)page.Audio.Id;
             Image = (int?)page.Image.Id;
-            Images = page.Images.Select(id => (int)id).ToList();
+            Images = page.Images.Select(img => new SliderPageImageResult(img)).ToList();
             HideYearNumbers = page.HideYearNumbers;
             AdditionalInformationPages = page.AdditionalInformationPages.Select(id => (int)id).ToList();
             Status = page.Status;

--- a/HiP-DataStore.Model/Rest/SliderPageImageArgs.cs
+++ b/HiP-DataStore.Model/Rest/SliderPageImageArgs.cs
@@ -1,0 +1,22 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
+{
+    public class SliderPageImageArgs
+    {
+        public int Date { get; set; }
+        public int Image { get; set; }
+    }
+
+    public class SliderPageImageResult
+    {
+        public int Date { get; set; }
+        public int Image { get; set; }
+
+        public SliderPageImageResult(SliderPageImage img)
+        {
+            Date = img.Date;
+            Image = (int)img.Image.Id;
+        }
+    }
+}

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -147,7 +147,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         [ProducesResponseType(typeof(int), 201)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> PostForExhibitAsync(int exhibitId, [FromBody]ExhibitPageArgs args)
+        public async Task<IActionResult> PostForExhibitAsync(int exhibitId, [FromBody]ExhibitPageArgs2 args)
         {
             ExhibitPageCommands.ValidateExhibitPageArgs(args, ModelState.AddModelError, _entityIndex, _mediaIndex);
 
@@ -170,7 +170,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         [ProducesResponseType(422)]
-        public async Task<IActionResult> PutAsync(int id, [FromBody]ExhibitPageArgs args)
+        public async Task<IActionResult> PutAsync(int id, [FromBody]ExhibitPageArgs2 args)
         {
             ExhibitPageCommands.ValidateExhibitPageArgs(args, ModelState.AddModelError, _entityIndex, _mediaIndex);
 

--- a/HiP-DataStore/Core/EventStoreClient.cs
+++ b/HiP-DataStore/Core/EventStoreClient.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using System.Reflection;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core
 {

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -96,6 +96,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                         var updatedPage = new ExhibitPage(e.Properties)
                         {
                             Id = e.Id,
+                            Exhibit = { Id = e.ExhibitId },
                             Timestamp = e.Timestamp
                         };
 

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -68,12 +68,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
             // Event types may change over time (properties get added/removed etc.)
             // Whenever an event has multiple versions, this method should transform an event of an outdated version
             // to an event of the latest version, so that ApplyEvent(...) only has to deal with events of the current version.
-            switch (ev)
+            while (ev is IMigratable<IEvent> migratableEvent)
             {
-                // Create cases for outdated event types here
+                ev = migratableEvent.Migrate();
             }
 
-            // no migration necessary, just return the event as is
             return ev;
         }
 
@@ -105,7 +104,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                     _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).DeleteOne(x => x.Id == e.Id);
                     break;
 
-                case ExhibitPageCreated e:
+                case ExhibitPageCreated2 e:
                     var newPage = new ExhibitPage(e.Properties)
                     {
                         Id = e.Id,
@@ -116,7 +115,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                     _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).InsertOne(newPage);
                     break;
 
-                case ExhibitPageUpdated e:
+                case ExhibitPageUpdated2 e:
                     var updatedPage = new ExhibitPage(e.Properties)
                     {
                         Id = e.Id,

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -54,165 +54,184 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
             try
             {
                 var ev = resolvedEvent.Event.ToIEvent();
-
-                switch (ev)
-                {
-                    case ExhibitCreated e:
-                        var newExhibit = new Exhibit(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).InsertOne(newExhibit);
-                        break;
-
-                    case ExhibitUpdated e:
-                        var updatedExhibit = new Exhibit(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).ReplaceOne(x => x.Id == e.Id, updatedExhibit);
-                        break;
-
-                    case ExhibitDeleted e:
-                        _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).DeleteOne(x => x.Id == e.Id);
-                        break;
-
-                    case ExhibitPageCreated e:
-                        var newPage = new ExhibitPage(e.Properties)
-                        {
-                            Id = e.Id,
-                            Exhibit = { Id = e.ExhibitId },
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).InsertOne(newPage);
-                        break;
-
-                    case ExhibitPageUpdated e:
-                        var updatedPage = new ExhibitPage(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).ReplaceOne(x => x.Id == e.Id, updatedPage);
-                        break;
-
-                    case ExhibitPageDeleted e:
-                        _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).DeleteOne(x => x.Id == e.Id);
-                        break;
-
-                    case RouteCreated e:
-                        var newRoute = new Route(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<Route>(ResourceType.Route.Name).InsertOne(newRoute);
-                        break;
-
-                    case RouteUpdated e:
-                        var updatedRoute = new Route(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<Route>(ResourceType.Route.Name).ReplaceOne(r => r.Id == e.Id, updatedRoute);
-                        break;
-
-                    case RouteDeleted e:
-                        _db.GetCollection<Route>(ResourceType.Route.Name).DeleteOne(r => r.Id == e.Id);
-                        break;
-
-                    case MediaCreated e:
-                        var newMedia = new MediaElement(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<MediaElement>(ResourceType.Media.Name).InsertOne(newMedia);
-                        break;
-
-                    case MediaUpdate e:
-                        var updatedMedia = new MediaElement(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp
-                        };
-
-                        _db.GetCollection<MediaElement>(ResourceType.Media.Name).ReplaceOne(m => m.Id == e.Id, updatedMedia);
-                        break;
-
-                    case MediaDeleted e:
-                        _db.GetCollection<MediaElement>(ResourceType.Media.Name).DeleteOne(m => m.Id == e.Id);
-                        break;
-                        
-                    case MediaFileUpdated e:
-                        var fileDocBson = e.ToBsonDocument();
-                        fileDocBson.Remove("_id");
-                        var bsonDoc = new BsonDocument("$set", fileDocBson);
-                        _db.GetCollection<MediaElement>(ResourceType.Media.Name).UpdateOne(x => x.Id == e.Id, bsonDoc);
-                        break;
-
-                    case TagCreated e:
-                        var newTag = new Tag(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp,
-                        };
-
-                        _db.GetCollection<Tag>(ResourceType.Tag.Name).InsertOne(newTag);
-                        break;
-
-                    case TagUpdated e:
-                        var updatedTag = new Tag(e.Properties)
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp,
-                        };
-
-                        _db.GetCollection<Tag>(ResourceType.Tag.Name).ReplaceOne(x => x.Id == e.Id, updatedTag);
-                        break;
-
-                    case TagDeleted e:
-                        _db.GetCollection<Tag>(ResourceType.Tag.Name).DeleteOne(x => x.Id == e.Id);
-                        break;
-
-                    case ReferenceAdded e:
-                        // a reference (source -> target) was added, so we have to create a new DocRef pointing to the
-                        // source and add it to the target's referencees list
-                        var newReference = new DocRef<ContentBase>(e.SourceId, e.SourceType.Name);
-                        var update = Builders<ContentBase>.Update.Push(nameof(ContentBase.Referencees), newReference);
-                        _db.GetCollection<ContentBase>(e.TargetType.Name).UpdateOne(x => x.Id == e.TargetId, update);
-                        break;
-
-                    case ReferenceRemoved e:
-                        // a reference (source -> target) was removed, so we have to delete the DocRef pointing to the
-                        // source from the target's referencees list
-
-                        // ladies and gentlemen, fasten your seatbelts and prepare for the
-                        // ugly truth of the MongoDB API:
-                        var update2 = Builders<dynamic>.Update.PullFilter(
-                            nameof(ContentBase.Referencees),
-                            Builders<dynamic>.Filter.And(
-                                Builders<dynamic>.Filter.Eq(nameof(DocRefBase.Collection), e.SourceType.Name),
-                                Builders<dynamic>.Filter.Eq("_id", e.SourceId)));
-
-                        _db.GetCollection<dynamic>(e.TargetType.Name).UpdateOne(
-                            Builders<dynamic>.Filter.Eq("_id", e.TargetId), update2);
-                        break;
-                }
+                var migratedEvent = MigrateEvent(ev);
+                ApplyEvent(migratedEvent);
             }
             catch (Exception e)
             {
                 _logger.LogWarning($"{nameof(CacheDatabaseManager)} could not process an event: {e}");
+            }
+        }
+
+        private IEvent MigrateEvent(IEvent ev)
+        {
+            // Event types may change over time (properties get added/removed etc.)
+            // Whenever an event has multiple versions, this method should transform an event of an outdated version
+            // to an event of the latest version, so that ApplyEvent(...) only has to deal with events of the current version.
+            switch (ev)
+            {
+                // Create cases for outdated event types here
+            }
+
+            // no migration necessary, just return the event as is
+            return ev;
+        }
+
+        private void ApplyEvent(IEvent ev)
+        {
+            switch (ev)
+            {
+                case ExhibitCreated e:
+                    var newExhibit = new Exhibit(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).InsertOne(newExhibit);
+                    break;
+
+                case ExhibitUpdated e:
+                    var updatedExhibit = new Exhibit(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).ReplaceOne(x => x.Id == e.Id, updatedExhibit);
+                    break;
+
+                case ExhibitDeleted e:
+                    _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).DeleteOne(x => x.Id == e.Id);
+                    break;
+
+                case ExhibitPageCreated e:
+                    var newPage = new ExhibitPage(e.Properties)
+                    {
+                        Id = e.Id,
+                        Exhibit = { Id = e.ExhibitId },
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).InsertOne(newPage);
+                    break;
+
+                case ExhibitPageUpdated e:
+                    var updatedPage = new ExhibitPage(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).ReplaceOne(x => x.Id == e.Id, updatedPage);
+                    break;
+
+                case ExhibitPageDeleted e:
+                    _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).DeleteOne(x => x.Id == e.Id);
+                    break;
+
+                case RouteCreated e:
+                    var newRoute = new Route(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<Route>(ResourceType.Route.Name).InsertOne(newRoute);
+                    break;
+
+                case RouteUpdated e:
+                    var updatedRoute = new Route(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<Route>(ResourceType.Route.Name).ReplaceOne(r => r.Id == e.Id, updatedRoute);
+                    break;
+
+                case RouteDeleted e:
+                    _db.GetCollection<Route>(ResourceType.Route.Name).DeleteOne(r => r.Id == e.Id);
+                    break;
+
+                case MediaCreated e:
+                    var newMedia = new MediaElement(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<MediaElement>(ResourceType.Media.Name).InsertOne(newMedia);
+                    break;
+
+                case MediaUpdate e:
+                    var updatedMedia = new MediaElement(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp
+                    };
+
+                    _db.GetCollection<MediaElement>(ResourceType.Media.Name).ReplaceOne(m => m.Id == e.Id, updatedMedia);
+                    break;
+
+                case MediaDeleted e:
+                    _db.GetCollection<MediaElement>(ResourceType.Media.Name).DeleteOne(m => m.Id == e.Id);
+                    break;
+
+                case MediaFileUpdated e:
+                    var fileDocBson = e.ToBsonDocument();
+                    fileDocBson.Remove("_id");
+                    var bsonDoc = new BsonDocument("$set", fileDocBson);
+                    _db.GetCollection<MediaElement>(ResourceType.Media.Name).UpdateOne(x => x.Id == e.Id, bsonDoc);
+                    break;
+
+                case TagCreated e:
+                    var newTag = new Tag(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp,
+                    };
+
+                    _db.GetCollection<Tag>(ResourceType.Tag.Name).InsertOne(newTag);
+                    break;
+
+                case TagUpdated e:
+                    var updatedTag = new Tag(e.Properties)
+                    {
+                        Id = e.Id,
+                        Timestamp = e.Timestamp,
+                    };
+
+                    _db.GetCollection<Tag>(ResourceType.Tag.Name).ReplaceOne(x => x.Id == e.Id, updatedTag);
+                    break;
+
+                case TagDeleted e:
+                    _db.GetCollection<Tag>(ResourceType.Tag.Name).DeleteOne(x => x.Id == e.Id);
+                    break;
+
+                case ReferenceAdded e:
+                    // a reference (source -> target) was added, so we have to create a new DocRef pointing to the
+                    // source and add it to the target's referencees list
+                    var newReference = new DocRef<ContentBase>(e.SourceId, e.SourceType.Name);
+                    var update = Builders<ContentBase>.Update.Push(nameof(ContentBase.Referencees), newReference);
+                    _db.GetCollection<ContentBase>(e.TargetType.Name).UpdateOne(x => x.Id == e.TargetId, update);
+                    break;
+
+                case ReferenceRemoved e:
+                    // a reference (source -> target) was removed, so we have to delete the DocRef pointing to the
+                    // source from the target's referencees list
+
+                    // ladies and gentlemen, fasten your seatbelts and prepare for the
+                    // ugly truth of the MongoDB API:
+                    var update2 = Builders<dynamic>.Update.PullFilter(
+                        nameof(ContentBase.Referencees),
+                        Builders<dynamic>.Filter.And(
+                            Builders<dynamic>.Filter.Eq(nameof(DocRefBase.Collection), e.SourceType.Name),
+                            Builders<dynamic>.Filter.Eq("_id", e.SourceId)));
+
+                    _db.GetCollection<dynamic>(e.TargetType.Name).UpdateOne(
+                        Builders<dynamic>.Filter.Eq("_id", e.TargetId), update2);
+                    break;
             }
         }
     }

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -123,6 +123,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
             var ev = new ExhibitPageUpdated
             {
                 Id = pageId,
+                ExhibitId = exhibitId,
                 Properties = args,
                 Timestamp = DateTimeOffset.Now
             };

--- a/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
@@ -22,7 +22,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         {
             switch (e)
             {
-                case ExhibitPageCreated ev:
+                case ExhibitPageCreated2 ev:
                     _pageType[ev.Id] = new PageInfo
                     {
                         Type = ev.Properties.Type,


### PR DESCRIPTION
This PR introduces the concept of "event versioning". This allows us to make changes to our event types (e.g. add or remove properties) while still being able to parse old events. To modify an event `MyEvent`:
* Create a modified version of the class and call it `MyEvent2`. Then, make `MyEvent` implement `IMigratable<MyEvent2>` so that events of type `MyEvent` can be "upgraded" to events of type `MyEvent2`.
* In `CacheDatabaseManager.ApplyEvent` modify the switch cases so that the method handles only events of type `MyEvent2` and no longer events of the old type
* Modify controller classes to emit events of type `MyEvent2` instead of `MyEvent`
* If necessary, create updated versions of the REST-types like `FooArgs2` or `FooResult2` (also by implementing `IMigratable` on the old classes)

The versioning concept has been used to modify exhibit pages: `ExhibitPage.Images` is now a list of pairs of date + image ID, instead of just the image ID.

Additionally, this PR includes the (potentially breaking) changes of branch 'page-update-fix': All exhibit pages that have ever been updated via a PUT call will be assigned to the exhibit with ID 0. So after this is merged, we should make sure that all pages are assigned to the correct exhibit - if not, pages need to be recreated.