### PR TITLE
Page result fields fix

### DIFF
--- a/HiP-DataStore.Model/Rest/ExhibitPageResult.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageResult.cs
@@ -30,7 +30,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 
         public IReadOnlyCollection<SliderPageImageResult> Images { get; set; }
 
-        public bool HideYearNumbers { get; set; }
+        public bool? HideYearNumbers { get; set; }
 
         public IReadOnlyCollection<int> AdditionalInformationPages { get; set; }
 
@@ -53,12 +53,24 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             Description = page.Description;
             FontFamily = page.FontFamily;
             Audio = (int?)page.Audio.Id;
-            Image = (int?)page.Image.Id;
-            Images = page.Images?.Select(img => new SliderPageImageResult(img)).ToArray() ?? Array.Empty<SliderPageImageResult>();
-            HideYearNumbers = page.HideYearNumbers;
             AdditionalInformationPages = page.AdditionalInformationPages.Select(id => (int)id).ToList();
             Status = page.Status;
             Timestamp = page.Timestamp;
+
+            // properties only valid for certain page types:
+
+            if (page.Type == PageType.Appetizer_Page || page.Type == PageType.Image_Page)
+            {
+                // 'image' only allowed for types APPETIZER_PAGE and IMAGE_PAGE
+                Image = (int?)page.Image.Id;
+            }
+
+            if (page.Type == PageType.Slider_Page)
+            {
+                // 'images' and 'hideYearNumbers' only allowed for type SLIDER_PAGE
+                Images = page.Images?.Select(img => new SliderPageImageResult(img)).ToArray() ?? Array.Empty<SliderPageImageResult>();
+                HideYearNumbers = page.HideYearNumbers;
+            }
         }
     }
 }

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -38,6 +38,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
             var mongo = new MongoClient(config.Value.MongoDbHost);
             mongo.DropDatabase(config.Value.MongoDbName);
             _db = mongo.GetDatabase(config.Value.MongoDbName);
+            logger.LogInformation($"Connected to MongoDB cache database, using database '{config.Value.MongoDbName}'");
 
             // 2) Subscribe to EventStore to receive all past and future events
             _eventStore = eventStore;


### PR DESCRIPTION
GET requests for exhibit pages now return only those fields that are valid for the page's type. All other page fields are assigned null. For example, the JSON from now on contains `"hideYearNumbers": null` for all page types except `SLIDER_PAGE`.