### PR TITLE
Changed type of ExhibitPage.Images.Date from int to string

### DIFF
--- a/HiP-DataStore.Model/Entity/SliderPageImage.cs
+++ b/HiP-DataStore.Model/Entity/SliderPageImage.cs
@@ -4,7 +4,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {
     public class SliderPageImage
     {
-        public int Date { get; set; }
+        public string Date { get; set; }
 
         public DocRef<MediaElement> Image { get; set; } =
             new DocRef<MediaElement>(ResourceType.Media.Name);

--- a/HiP-DataStore.Model/Rest/ExhibitPageArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageArgs.cs
@@ -64,7 +64,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             // for migration of the 'Images' property, we have to choose an arbitrary default date
             Images = Images?.Select(imageId => new SliderPageImageArgs
             {
-                Date = 2017,
+                Date = "2017",
                 Image = imageId
             }).ToList(),
 

--- a/HiP-DataStore.Model/Rest/SliderPageImageArgs.cs
+++ b/HiP-DataStore.Model/Rest/SliderPageImageArgs.cs
@@ -4,13 +4,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 {
     public class SliderPageImageArgs
     {
-        public int Date { get; set; }
+        public string Date { get; set; }
         public int Image { get; set; }
     }
 
     public class SliderPageImageResult
     {
-        public int Date { get; set; }
+        public string Date { get; set; }
         public int Image { get; set; }
 
         public SliderPageImageResult(SliderPageImage img)


### PR DESCRIPTION
The date for images of a slider page is now of type `string` to enable arbitrary date descriptions like "20th century". No migration code is necessary, all existing events still having an `int`-date can be automatically parsed as `string`.