### PR TITLE
Changes to allow page ordering

### DIFF
--- a/HiP-DataStore.Model/Entity/Exhibit.cs
+++ b/HiP-DataStore.Model/Entity/Exhibit.cs
@@ -7,12 +7,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {
     public class Exhibit : ContentBase
     {
-        [BsonElement(nameof(Image))]
-        private DocRef<MediaElement> _image = new DocRef<MediaElement>(ResourceType.Media.Name);
-
-        [BsonElement(nameof(Tags))]
-        private DocRefList<Tag> _tags = new DocRefList<Tag>(ResourceType.Tag.Name);
-
         public string Name { get; set; }
 
         public string Description { get; set; }
@@ -21,9 +15,21 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 
         public float Longitude { get; set; }
 
-        public DocRef<MediaElement> Image => _image;
+        [BsonElement]
+        public DocRef<MediaElement> Image { get; private set; } =
+            new DocRef<MediaElement>(ResourceType.Media.Name);
 
-        public DocRefList<Tag> Tags => _tags;
+        [BsonElement]
+        public DocRefList<Tag> Tags { get; private set; } =
+            new DocRefList<Tag>(ResourceType.Tag.Name);
+
+        /// <remarks>
+        /// This property and the references from pages to exhibit should always be in sync.
+        /// Thus, when pages are created/deleted for a specific exhibit, that exhibit's Pages property must be updated.
+        /// </remarks>
+        [BsonElement]
+        public DocRefList<ExhibitPage> Pages { get; private set; } =
+            new DocRefList<ExhibitPage>(ResourceType.ExhibitPage.Name);
 
         public Exhibit()
         {
@@ -38,6 +44,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
             Longitude = args.Longitude;
             Status = args.Status;
             Tags.Add(args.Tags?.Select(id => (BsonValue)id));
+        }
+
+        public Exhibit(ExhibitUpdateArgs args) : this((ExhibitArgs)args)
+        {
+            Pages.Add(args.Pages?.Select(id => (BsonValue)id));
         }
     }
 }

--- a/HiP-DataStore.Model/Entity/Route.cs
+++ b/HiP-DataStore.Model/Entity/Route.cs
@@ -8,19 +8,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
     public class Route : ContentBase
     {
         // TODO: What about waypoints?
-
-        [BsonElement(nameof(Image))]
-        private DocRef<MediaElement> _image = new DocRef<MediaElement>(ResourceType.Media.Name);
-
-        [BsonElement(nameof(Audio))]
-        private DocRef<MediaElement> _audio = new DocRef<MediaElement>(ResourceType.Media.Name);
-
-        [BsonElement(nameof(Exhibits))]
-        private DocRefList<Exhibit> _exhibits = new DocRefList<Exhibit>(ResourceType.Exhibit.Name);
-
-        [BsonElement(nameof(Tags))]
-        private DocRefList<Tag> _tags = new DocRefList<Tag>(ResourceType.Tag.Name);
-
+        
         public string Title { get; set; }
 
         public string Description { get; set; }
@@ -29,13 +17,21 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 
         public double Distance { get; set; }
 
-        public DocRef<MediaElement> Image => _image;
+        [BsonElement]
+        public DocRef<MediaElement> Image { get; private set; } =
+            new DocRef<MediaElement>(ResourceType.Media.Name);
 
-        public DocRef<MediaElement> Audio => _audio;
+        [BsonElement]
+        public DocRef<MediaElement> Audio { get; private set; } =
+            new DocRef<MediaElement>(ResourceType.Media.Name);
 
-        public DocRefList<Exhibit> Exhibits => _exhibits;
+        [BsonElement]
+        public DocRefList<Exhibit> Exhibits { get; private set; } =
+            new DocRefList<Exhibit>(ResourceType.Exhibit.Name);
 
-        public DocRefList<Tag> Tags => _tags;
+        [BsonElement]
+        public DocRefList<Tag> Tags { get; private set; } =
+            new DocRefList<Tag>(ResourceType.Tag.Name);
 
         public Route()
         {

--- a/HiP-DataStore.Model/Entity/SliderPageImage.cs
+++ b/HiP-DataStore.Model/Entity/SliderPageImage.cs
@@ -1,4 +1,5 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+﻿using MongoDB.Bson.Serialization.Attributes;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {
@@ -6,7 +7,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
     {
         public string Date { get; set; }
 
-        public DocRef<MediaElement> Image { get; set; } =
+        [BsonElement]
+        public DocRef<MediaElement> Image { get; private set; } =
             new DocRef<MediaElement>(ResourceType.Media.Name);
 
         public SliderPageImage()

--- a/HiP-DataStore.Model/Entity/Tag.cs
+++ b/HiP-DataStore.Model/Entity/Tag.cs
@@ -5,14 +5,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {
     public class Tag : ContentBase
     {
-        [BsonElement(nameof(Image))]
-        private DocRef<MediaElement> _image = new DocRef<MediaElement>(ResourceType.Media.Name);
-
         public string Title { get; set; }
 
         public string Description { get; set; }
 
-        public DocRef<MediaElement> Image => _image;
+        [BsonElement]
+        public DocRef<MediaElement> Image { get; private set; } =
+            new DocRef<MediaElement>(ResourceType.Media.Name);
 
         public Tag()
         {

--- a/HiP-DataStore.Model/Events/ExhibitPageCreated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageCreated.cs
@@ -18,6 +18,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
         public ContentStatus GetStatus() => Properties.Status;
     }
 
+    [Obsolete]
     public class ExhibitPageCreated : ICreateEvent, IMigratable<ExhibitPageCreated2>
     {
         public int Id { get; set; }

--- a/HiP-DataStore.Model/Events/ExhibitPageDeleted.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageDeleted.cs
@@ -1,9 +1,27 @@
-﻿namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
+﻿using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
-    public class ExhibitPageDeleted : IDeleteEvent
+    public class ExhibitPageDeleted2 : IDeleteEvent
+    {
+        public int Id { get; set; }
+
+        public int ExhibitId { get; set; }
+
+        public ResourceType GetEntityType() => ResourceType.ExhibitPage;
+    }
+
+    [Obsolete]
+    public class ExhibitPageDeleted : IDeleteEvent, IMigratable<ExhibitPageDeleted2>
     {
         public int Id { get; set; }
 
         public ResourceType GetEntityType() => ResourceType.ExhibitPage;
+
+        public ExhibitPageDeleted2 Migrate() => new ExhibitPageDeleted2
+        {
+            Id = Id,
+            ExhibitId = -1
+        };
     }
 }

--- a/HiP-DataStore.Model/Events/ExhibitPageDeleted.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageDeleted.cs
@@ -2,6 +2,8 @@
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
+    // Version info: Added ExhibitId, so that the ID of the deleted page can be removed from the
+    // ordered list "Exhibit.Pages" of the corresponding exhibit
     public class ExhibitPageDeleted2 : IDeleteEvent
     {
         public int Id { get; set; }

--- a/HiP-DataStore.Model/Events/ExhibitPageDeleted.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageDeleted.cs
@@ -1,29 +1,11 @@
-﻿using System;
-
-namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
+﻿namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
-    // Version info: Added ExhibitId, so that the ID of the deleted page can be removed from the
-    // ordered list "Exhibit.Pages" of the corresponding exhibit
-    public class ExhibitPageDeleted2 : IDeleteEvent
+    public class ExhibitPageDeleted : IDeleteEvent
     {
         public int Id { get; set; }
 
         public int ExhibitId { get; set; }
 
         public ResourceType GetEntityType() => ResourceType.ExhibitPage;
-    }
-
-    [Obsolete]
-    public class ExhibitPageDeleted : IDeleteEvent, IMigratable<ExhibitPageDeleted2>
-    {
-        public int Id { get; set; }
-
-        public ResourceType GetEntityType() => ResourceType.ExhibitPage;
-
-        public ExhibitPageDeleted2 Migrate() => new ExhibitPageDeleted2
-        {
-            Id = Id,
-            ExhibitId = -1
-        };
     }
 }

--- a/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
@@ -18,6 +18,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
         public ContentStatus GetStatus() => Properties.Status;
     }
 
+    [Obsolete]
     public class ExhibitPageUpdated : IUpdateEvent, IMigratable<ExhibitPageUpdated2>
     {
         public int Id { get; set; }

--- a/HiP-DataStore.Model/Events/ExhibitUpdated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitUpdated.cs
@@ -7,7 +7,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
     {
         public int Id { get; set; }
 
-        public ExhibitArgs Properties { get; set; }
+        public ExhibitUpdateArgs Properties { get; set; }
 
         public DateTimeOffset Timestamp { get; set; }
 

--- a/HiP-DataStore.Model/Rest/ExhibitResult.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitResult.cs
@@ -43,7 +43,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             Image = (int?)x.Image.Id;
             Latitude = x.Latitude;
             Longitude = x.Longitude;
-            Used = x.Referencees.Any(r => r.Collection == ResourceType.Route.Name); // an exhibit is in use if it is contained in a route
+            Used = x.Referencees.Count > 0; // an exhibit is in use if it is contained in (i.e. referenced by) a route
             Pages = x.Pages.Select(id => (int)id).ToArray();
             Status = x.Status;
             Tags = x.Tags.Select(id => (int)id).ToArray();

--- a/HiP-DataStore.Model/Rest/ExhibitResult.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitResult.cs
@@ -44,7 +44,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             Latitude = x.Latitude;
             Longitude = x.Longitude;
             Used = x.Referencees.Any(r => r.Collection == ResourceType.Route.Name); // an exhibit is in use if it is contained in a route
-            Pages = x.Referencees.Where(r => r.Collection == ResourceType.ExhibitPage.Name).Select(r => (int)r.Id).ToArray();
+            Pages = x.Pages.Select(id => (int)id).ToArray();
             Status = x.Status;
             Tags = x.Tags.Select(id => (int)id).ToArray();
             Timestamp = x.Timestamp;

--- a/HiP-DataStore.Model/Rest/ExhibitUpdateArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitUpdateArgs.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
+{
+    /// <summary>
+    /// Model for updating exhibits.
+    /// </summary>
+    public class ExhibitUpdateArgs : ExhibitArgs
+    {
+        public List<int> Pages { get; set; }
+    }
+}

--- a/HiP-DataStore/Controllers/ErrorMessages.cs
+++ b/HiP-DataStore/Controllers/ErrorMessages.cs
@@ -30,5 +30,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         public static string CannotChangeExhibitPageType(PageType currentType, PageType newType) =>
             $"The type of an exhibit page cannot be changed (current type is '{currentType}', attempted to change to '{newType}')";
+
+        public static string ExhibitPageOnlyReorderAllowed =>
+            "The set of specified page IDs differs from the set of pages actually belonging to the exhibit. Addition and removal of pages is not supported by the PUT API, only reordering of pages is.";
     }
 }

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -224,7 +224,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (_referencesIndex.IsUsed(ResourceType.ExhibitPage, id))
                 return BadRequest(ErrorMessages.ResourceInUse);
 
-            var events = ExhibitPageCommands.Delete(id, _referencesIndex);
+            var events = ExhibitPageCommands.Delete(id, _referencesIndex, _exhibitPageIndex);
             await _eventStore.AppendEventsAsync(events);
 
             return NoContent();

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -85,11 +85,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (exhibit == null)
                 return NotFound();
 
-            var allPageIds = exhibit.Referencees
-                .Where(r => r.Collection == ResourceType.ExhibitPage.Name)
-                .Select(r => r.Id);
-
-            var pageIds = new DocRefList<ExhibitPage>(allPageIds, ResourceType.ExhibitPage.Name)
+            var pageIds = exhibit.Pages
                 .LoadAll(_db.Database)
                 .Where(p => status == ContentStatus.All || p.Status == status)
                 .Select(p => p.Id)
@@ -116,13 +112,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
             if (exhibit == null)
                 return NotFound();
-
-            var pageIds = exhibit.Referencees
-                .Where(r => r.Collection == ResourceType.ExhibitPage.Name)
-                .Select(r => r.Id);
-
-            var pageRefs = new DocRefList<ExhibitPage>(pageIds, ResourceType.ExhibitPage.Name);
-            var query = pageRefs.LoadAll(_db.Database).AsQueryable();
+            
+            var query = exhibit.Pages.LoadAll(_db.Database).AsQueryable();
 
             return QueryExhibitPages(query, args);
         }

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -255,18 +255,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 await _eventStore.AppendEventAsync(tagRef);
             }
         }
-
-        private async Task AddExhibitReferencesAsync(ExhibitUpdateArgs args, int exhibitId)
-        {
-            await AddExhibitReferencesAsync((ExhibitArgs)args, exhibitId);
-
-            foreach (var pageId in args.Pages ?? Enumerable.Empty<int>())
-            {
-                var pageRef = new ReferenceAdded(ResourceType.Exhibit, exhibitId, ResourceType.ExhibitPage, pageId);
-                await _eventStore.AppendEventAsync(pageRef);
-            }
-        }
-
+        
         private async Task RemoveExhibitReferencesAsync(int exhibitId)
         {
             foreach (var reference in _referencesIndex.ReferencesOf(ResourceType.Exhibit, exhibitId))

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -159,6 +159,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpDelete("{id}")]
         [ProducesResponseType(204)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         public async Task<IActionResult> DeleteAsync(int id)
         {

--- a/HiP-DataStore/Core/EventStoreClient.cs
+++ b/HiP-DataStore/Core/EventStoreClient.cs
@@ -93,7 +93,16 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
                 totalCount++;
 
                 foreach (var index in _indices)
-                    index.ApplyEvent(events.Current);
+                {
+                    try
+                    {
+                        index.ApplyEvent(events.Current);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogWarning($"Failed to populate index of type '{index.GetType().Name}' with event of type '{events.Current.GetType().Name}': {e}");
+                    }
+                }
             }
 
             _logger.LogInformation($"Populated indices with {totalCount} events");

--- a/HiP-DataStore/Core/EventStoreStreamEnumerator.cs
+++ b/HiP-DataStore/Core/EventStoreStreamEnumerator.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using EventStore.ClientAPI;
+using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    /// <summary>
+    /// Provides an easy-to-consume async enumerator to iterate over all events in an Event Store stream.
+    /// </summary>
+    public class EventStoreStreamEnumerator : IAsyncEnumerator<IEvent>
+    {
+        private const int PageSize = 4096; // only 4096 events can be retrieved in one call
+
+        private readonly IEventStoreConnection _connection;
+        private readonly string _streamName;
+        private readonly Queue<IEvent> _buffer = new Queue<IEvent>();
+
+        private long _startPosition = StreamPosition.Start;
+        private bool _isEndOfStream = false;
+
+        public IEvent Current => _buffer.Peek();
+
+        public event EventHandler<EventParsingException> EventParsingFailed;
+
+        public EventStoreStreamEnumerator(IEventStoreConnection connection, string streamName)
+        {
+            _connection = connection;
+            _streamName = streamName;
+        }
+
+        public async Task<bool> MoveNextAsync()
+        {
+            if (_buffer.Count > 0)
+            {
+                _buffer.Dequeue();
+                return _buffer.Count > 0;
+            }
+
+            if (_isEndOfStream)
+                return false;
+
+            // Why the 'while'? If the stream was soft-deleted in the past it starts at an event with number != 0.
+            // So the first read operation returns 0 events, but reports the actual start position of the stream
+            // (currentSlice.NextEventNumber). Then, a second read is required to actually read the first few events.
+            while (_buffer.Count == 0 && !_isEndOfStream)
+            {
+                var currentSlice = await _connection.ReadStreamEventsForwardAsync(_streamName, _startPosition, PageSize, false);
+
+                foreach (var eventData in currentSlice.Events)
+                {
+                    try
+                    {
+                        var ev = eventData.Event.ToIEvent().MigrateToLatestVersion();
+                        _buffer.Enqueue(ev);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        EventParsingFailed?.Invoke(this, new EventParsingException(eventData, e));
+                    }
+                }
+
+                _startPosition = currentSlice.NextEventNumber;
+                _isEndOfStream = currentSlice.IsEndOfStream;
+            }
+
+            return _buffer.Count > 0;
+        }
+
+        public void Reset()
+        {
+            _startPosition = 0;
+            _isEndOfStream = false;
+            _buffer.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The exception that is thrown when raw event data cannot be deserialized into a corresponding CLR object.
+    /// </summary>
+    public class EventParsingException : Exception
+    {
+        public ResolvedEvent RawEvent { get; }
+
+        public EventParsingException(ResolvedEvent rawEvent, Exception innerException)
+            : base($"The event data of type '{rawEvent.Event.EventType}' could not be deserialized into " +
+                   $"an instance of '{nameof(IEvent)}'", innerException)
+        {
+            RawEvent = rawEvent;
+        }
+    }
+}

--- a/HiP-DataStore/Core/EventStoreStreamEnumerator.cs
+++ b/HiP-DataStore/Core/EventStoreStreamEnumerator.cs
@@ -18,7 +18,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
         private readonly Queue<IEvent> _buffer = new Queue<IEvent>();
 
         private long _startPosition = StreamPosition.Start;
-        private bool _isEndOfStream = false;
+        private bool _isEndOfStream;
 
         public IEvent Current => _buffer.Peek();
 

--- a/HiP-DataStore/Core/HipStreamMetadata.cs
+++ b/HiP-DataStore/Core/HipStreamMetadata.cs
@@ -1,0 +1,7 @@
+﻿namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    public class HipStreamMetadata
+    {
+        public int StreamVersion { get; set; }
+    }
+}

--- a/HiP-DataStore/Core/HipStreamMetadata.cs
+++ b/HiP-DataStore/Core/HipStreamMetadata.cs
@@ -1,7 +1,0 @@
-﻿namespace PaderbornUniversity.SILab.Hip.DataStore.Core
-{
-    public class HipStreamMetadata
-    {
-        public int StreamVersion { get; set; }
-    }
-}

--- a/HiP-DataStore/Core/IAsyncEnumerator.cs
+++ b/HiP-DataStore/Core/IAsyncEnumerator.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    /// <summary>
+    /// An asynchronous enumerator interface, similar to the built-in synchronous
+    /// <see cref="System.Collections.Generic.IEnumerator{T}"/> interface.
+    /// </summary>
+    public interface IAsyncEnumerator<out T>
+    {
+        /// <summary>
+        /// Gets the element in the collection at the current position of the enumerator.
+        /// </summary>
+        T Current { get; }
+
+        /// <summary>
+        /// Advances the enumerator to the next element of the collection.
+        /// </summary>
+        /// <returns>True if successfully moved.</returns>
+        Task<bool> MoveNextAsync();
+
+        /// <summary>
+        /// Sets the enumerator to its initial position, which is before the first element in the collection.
+        /// </summary>
+        void Reset();
+    }
+}

--- a/HiP-DataStore/Core/Migrations/IStreamMigration.cs
+++ b/HiP-DataStore/Core/Migrations/IStreamMigration.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    /// <summary>
+    /// The interface for Event Store stream migrations.
+    /// </summary>
+    /// <remarks>
+    /// Migrations are applied using the <see cref="StreamMigrator"/> class. In order for <see cref="StreamMigrator"/>
+    /// to recognize a migration class, the class must implement <see cref="IStreamMigration"/> and must be annotated
+    /// with the <see cref="StreamMigrationAttribute"/>.
+    /// </remarks>
+    public interface IStreamMigration
+    {
+        Task MigrateAsync(IStreamMigrationArgs e);
+    }
+}

--- a/HiP-DataStore/Core/Migrations/IStreamMigrationArgs.cs
+++ b/HiP-DataStore/Core/Migrations/IStreamMigrationArgs.cs
@@ -1,0 +1,10 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    public interface IStreamMigrationArgs
+    {
+        IAsyncEnumerator<IEvent> GetExistingEvents();
+        void AppendEvent(IEvent ev);
+    }
+}

--- a/HiP-DataStore/Core/Migrations/StreamMigrationArgs.cs
+++ b/HiP-DataStore/Core/Migrations/StreamMigrationArgs.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using EventStore.ClientAPI;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    public class StreamMigrationArgs : IStreamMigrationArgs
+    {
+        private readonly IEventStoreConnection _connection;
+        private readonly string _streamName;
+        private readonly List<IEvent> _eventsToAppend = new List<IEvent>();
+
+        public IReadOnlyList<IEvent> EventsToAppend => _eventsToAppend;
+
+        public StreamMigrationArgs(IEventStoreConnection connection, string streamName)
+        {
+            _connection = connection;
+            _streamName = streamName;
+        }
+
+        public void AppendEvent(IEvent ev) => _eventsToAppend.Add(ev);
+
+        public IAsyncEnumerator<IEvent> GetExistingEvents() =>
+            new EventStoreStreamEnumerator(_connection, _streamName);
+    }
+}

--- a/HiP-DataStore/Core/Migrations/StreamMigrationAttribute.cs
+++ b/HiP-DataStore/Core/Migrations/StreamMigrationAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    /// <summary>
+    /// Specifies the version for which a migration is applicable and the version the migration transforms the stream to.
+    /// </summary>
+    /// <remarks>
+    /// Migrations are applied using the <see cref="StreamMigrator"/> class. In order for <see cref="StreamMigrator"/>
+    /// to recognize a migration class, the class must implement <see cref="IStreamMigration"/> and must be annotated
+    /// with the <see cref="StreamMigrationAttribute"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class StreamMigrationAttribute : Attribute
+    {
+        /// <summary>
+        /// The stream version this migration is able to process.
+        /// </summary>
+        public int FromVersion { get; }
+
+        /// <summary>
+        /// The version the stream is migrated to.
+        /// </summary>
+        public int ToVersion { get; }
+
+        public StreamMigrationAttribute(int from, int to)
+        {
+            FromVersion = from;
+            ToVersion = to;
+        }
+    }
+}

--- a/HiP-DataStore/Core/Migrations/StreamMigrator.cs
+++ b/HiP-DataStore/Core/Migrations/StreamMigrator.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using System;
+using System.Reflection;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    /// <summary>
+    /// Provides methods to update an Event Store stream to the latest version by applying one or multiple
+    /// migrations defined in the HiP-DataStore assembly.
+    /// </summary>
+    public static class StreamMigrator
+    {
+        public const string StreamVersionMetadataKey = "StreamVersion";
+
+        public static async Task<(int fromVersion, int toVersion)> MigrateAsync(IEventStoreConnection connection, string streamName)
+        {
+            // Get current stream version from metadata
+            var initialVersion = await GetStreamVersionAsync(connection, streamName) ?? 0;
+            var currentVersion = initialVersion;
+            
+            // Find all applicable migrations in the current assembly
+            var availableMigrations = GetAvailableMigrations()
+                .Where(t => t.Properties.FromVersion >= currentVersion)
+                .OrderBy(t => t.Properties.FromVersion)
+                .ToList();
+
+            // Check for ambiguities (i.e. are there multiple migrations for the same source version?)
+            if (availableMigrations.GroupBy(t => t.Properties.FromVersion).Any(g => g.Count() > 1))
+                throw new InvalidOperationException("The assembly defines multiple migrations for the same source version");
+
+            // Repeatedly apply the migration with FromVersion == currentVersion and maximum ToVersion,
+            // until no more migrations are applicable
+            MigrationTypeInfo chosenMigration;
+
+            while ((chosenMigration = availableMigrations.FirstOrDefault(t => t.Properties.FromVersion == currentVersion)) != null)
+            {
+                // from the group of matching migrations, choose the one with maximum ToVersion
+                await ExecuteMigrationAsync(chosenMigration, connection, streamName);
+                currentVersion = chosenMigration.Properties.ToVersion;
+            }
+
+            return (initialVersion, currentVersion);
+        }
+
+        private static async Task<int?> GetStreamVersionAsync(IEventStoreConnection connection, string streamName)
+        {
+            var metadata = await connection.GetStreamMetadataAsync(streamName);
+            return metadata.StreamMetadata.TryGetValue(StreamVersionMetadataKey, out int version)
+                ? version
+                : default(int?);
+        }
+
+        private static IEnumerable<MigrationTypeInfo> GetAvailableMigrations()
+        {
+            return typeof(StreamMigrator).GetTypeInfo().Assembly.DefinedTypes
+                .Where(t => t.GetInterface(nameof(IStreamMigration)) != null)
+                .Select(t => new MigrationTypeInfo
+                {
+                    Type = t,
+                    Properties = t.GetCustomAttribute<StreamMigrationAttribute>()
+                })
+                .Where(t =>
+                    t.Properties != null && // type must have the [StreamMigration]-attribute
+                    t.Properties.ToVersion > t.Properties.FromVersion);
+        }
+
+        private static async Task ExecuteMigrationAsync(MigrationTypeInfo migrationType, IEventStoreConnection connection, string streamName)
+        {
+            var migration = (IStreamMigration)Activator.CreateInstance(migrationType.Type.AsType());
+            var args = new StreamMigrationArgs(connection, streamName);
+            await migration.MigrateAsync(args);
+
+            using (var transaction = await connection.StartTransactionAsync(streamName, ExpectedVersion.Any))
+            {
+                // Soft-delete the stream and recreate it by appending all new events
+                var events = args.EventsToAppend.Select(ev => ev.ToEventData(Guid.NewGuid()));
+                await connection.DeleteStreamAsync(streamName, ExpectedVersion.Any, hardDelete: false);
+                await connection.AppendToStreamAsync(streamName, ExpectedVersion.Any, events);
+
+                // Write new version to the stream's metadata
+                var metadata = await connection.GetStreamMetadataAsync(streamName);
+                var updatedMetadata = metadata.StreamMetadata.Copy()
+                    .SetCustomProperty(StreamVersionMetadataKey, migrationType.Properties.ToVersion);
+                await connection.SetStreamMetadataAsync(streamName, metadata.MetastreamVersion, updatedMetadata);
+
+                await transaction.CommitAsync();
+            }
+        }
+
+        class MigrationTypeInfo
+        {
+            public TypeInfo Type { get; set; }
+            public StreamMigrationAttribute Properties { get; set; }
+        }
+    }
+}

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -123,7 +123,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                     _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).ReplaceOne(x => x.Id == e.Id, updatedPage);
                     break;
 
-                case ExhibitPageDeleted2 e:
+                case ExhibitPageDeleted e:
                     // 1) delete the page
                     _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).DeleteOne(x => x.Id == e.Id);
 

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -96,6 +96,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                     break;
 
                 case ExhibitPageCreated2 e:
+                    // 1) create the page
                     var newPage = new ExhibitPage(e.Properties)
                     {
                         Id = e.Id,
@@ -104,6 +105,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                     };
 
                     _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).InsertOne(newPage);
+
+                    // 2) append page ID to pages array of corresponding exhibit
+                    var addPage = Builders<Exhibit>.Update.Push(x => x.Pages, e.Id);
+                    _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).UpdateOne(x => x.Id == e.ExhibitId, addPage);
                     break;
 
                 case ExhibitPageUpdated2 e:
@@ -117,8 +122,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
                     _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).ReplaceOne(x => x.Id == e.Id, updatedPage);
                     break;
 
-                case ExhibitPageDeleted e:
+                case ExhibitPageDeleted2 e:
+                    // 1) delete the page
                     _db.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).DeleteOne(x => x.Id == e.Id);
+
+                    // 2) remove page ID from pages array of corresponding exhibit
+                    var removePage = Builders<Exhibit>.Update.Pull(x => x.Pages, e.Id);
+                    _db.GetCollection<Exhibit>(ResourceType.Exhibit.Name).UpdateOne(x => x.Id == e.ExhibitId, removePage);
                     break;
 
                 case RouteCreated e:

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -113,7 +113,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
             // ReSharper disable once PossibleInvalidOperationException
             var exhibitId = pageIndex.ExhibitId(pageId).Value;
 
-            var ev = new ExhibitPageDeleted2 { Id = pageId, ExhibitId = exhibitId };
+            var ev = new ExhibitPageDeleted { Id = pageId, ExhibitId = exhibitId };
             var removeRefEvents = RemoveExhibitPageReferences(pageId, referencesIndex);
 
             // remove references, then delete the page

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -72,9 +72,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
 
         private static IEnumerable<IEvent> AddExhibitPageReferences(int pageId, int exhibitId, ExhibitPageArgs2 args)
         {
-            // pages have a reference to the exhibit they belong to, so an exhibit can determine its pages via Exhibit.Referencees
-            yield return new ReferenceAdded(ResourceType.ExhibitPage, pageId, ResourceType.Exhibit, exhibitId);
-
             if (args.Audio != null)
                 yield return new ReferenceAdded(ResourceType.ExhibitPage, pageId, ResourceType.Media, args.Audio.Value);
 

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -70,7 +70,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
             }
         }
 
-        private static IEnumerable<IEvent> AddExhibitPageReferences(int pageId, int exhibitId, ExhibitPageArgs2 args)
+        private static IEnumerable<IEvent> AddExhibitPageReferences(int pageId, ExhibitPageArgs2 args)
         {
             if (args.Audio != null)
                 yield return new ReferenceAdded(ResourceType.ExhibitPage, pageId, ResourceType.Media, args.Audio.Value);
@@ -102,7 +102,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
                 Timestamp = DateTimeOffset.Now
             };
 
-            var addRefEvents = AddExhibitPageReferences(pageId, exhibitId, args);
+            var addRefEvents = AddExhibitPageReferences(pageId, args);
 
             // create the page, then add references
             return addRefEvents.Prepend(ev);
@@ -135,7 +135,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
                 Timestamp = DateTimeOffset.Now
             };
 
-            var addRefEvents = AddExhibitPageReferences(pageId, exhibitId, args);
+            var addRefEvents = AddExhibitPageReferences(pageId, args);
 
             // remove old references, then update the page, then add new references
             return removeRefEvents.Append(ev).Concat(addRefEvents);

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -111,9 +111,12 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
             return addRefEvents.Prepend(ev);
         }
 
-        public static IEnumerable<IEvent> Delete(int pageId, ReferencesIndex referencesIndex)
+        public static IEnumerable<IEvent> Delete(int pageId, ReferencesIndex referencesIndex, ExhibitPageIndex pageIndex)
         {
-            var ev = new ExhibitPageDeleted { Id = pageId };
+            // ReSharper disable once PossibleInvalidOperationException
+            var exhibitId = pageIndex.ExhibitId(pageId).Value;
+
+            var ev = new ExhibitPageDeleted2 { Id = pageId, ExhibitId = exhibitId };
             var removeRefEvents = RemoveExhibitPageReferences(pageId, referencesIndex);
 
             // remove references, then delete the page

--- a/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
@@ -30,7 +30,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
                     };
                     break;
 
-                case ExhibitPageDeleted ev:
+                case ExhibitPageDeleted2 ev:
                     _pageType.Remove(ev.Id);
                     break;
             }

--- a/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
@@ -1,11 +1,13 @@
 ﻿using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using System;
 using System.Collections.Generic;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
 {
     public class ExhibitPageIndex : IDomainIndex
     {
+        private readonly Dictionary<int, List<int>> _exhibitPages = new Dictionary<int, List<int>>();
         private readonly Dictionary<int, PageInfo> _pageType = new Dictionary<int, PageInfo>();
 
         /// <summary>
@@ -18,6 +20,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         /// </summary>
         public int? ExhibitId(int pageId) => _pageType.TryGetValue(pageId, out var t) ? t.ExhibitId : default(int?);
 
+        /// <summary>
+        /// Gets the ordered list of page IDs for a specific exhibit.
+        /// </summary>
+        public IReadOnlyList<int> PageIds(int exhibitId) => GetPageListForExhibitOrNull(exhibitId)?.ToArray() ?? Array.Empty<int>();
+
         public void ApplyEvent(IEvent e)
         {
             switch (e)
@@ -28,12 +35,33 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
                         Type = ev.Properties.Type,
                         ExhibitId = ev.ExhibitId
                     };
+
+                    GetOrCreatePageListForExhibit(ev.ExhibitId).Add(ev.Id);
                     break;
 
                 case ExhibitPageDeleted2 ev:
                     _pageType.Remove(ev.Id);
+                    GetPageListForExhibitOrNull(ev.ExhibitId)?.Remove(ev.Id);
+                    break;
+
+                case ExhibitUpdated ev:
+                    _exhibitPages[ev.Id] = ev.Properties.Pages ?? new List<int>();
+                    break;
+
+                case ExhibitDeleted ev:
+                    _exhibitPages.Remove(ev.Id);
                     break;
             }
+        }
+
+        private List<int> GetPageListForExhibitOrNull(int exhibitId) =>
+            _exhibitPages.TryGetValue(exhibitId, out var list) ? list : null;
+
+        private List<int> GetOrCreatePageListForExhibit(int exhibitId)
+        {
+            return _exhibitPages.TryGetValue(exhibitId, out var list)
+                ? list
+                : (_exhibitPages[exhibitId] = new List<int>());
         }
 
         public class PageInfo

--- a/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
@@ -39,7 +39,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
                     GetOrCreatePageListForExhibit(ev.ExhibitId).Add(ev.Id);
                     break;
 
-                case ExhibitPageDeleted2 ev:
+                case ExhibitPageDeleted ev:
                     _pageType.Remove(ev.Id);
                     GetPageListForExhibitOrNull(ev.ExhibitId)?.Remove(ev.Id);
                     break;

--- a/HiP-DataStore/Migrations/AboutMigration.md
+++ b/HiP-DataStore/Migrations/AboutMigration.md
@@ -1,0 +1,18 @@
+# About Migration and Versioning
+HiP-DataStore uses two kinds of "migrations" to make changes to the data model without loosing existing data.
+
+## Event Migration
+A light way of migration that is useful if small modifications to event types need to be made. For example, adding a property to an `ExhibitCreated`-event or changing the type of a property are good candidates for event migrations. Event migrations are applied "on the fly", i.e. whenever an event of an outdated type is read from the Event Store, it is transformed into an event of the new type.
+
+How to implement an event migration:
+1. Create a copy of the event type you want to modify, e.g. `FooCreated`, and append a version number to the type's name, e.g. `FooCreated2` (future versions of the event type should be called `FooCreated3`, `FooCreated4` and so on).
+1. Make changes to `FooCreated2`, e.g. add/remove properties, change property types etc. If `FooCreated` contained a property of a custom type, such as `FooArgs`, and you need to make changes to `FooArgs`, then you also need to create a copy of that and name it `FooArgs2`.
+1. Make `FooCreated` implement `IMigratable<FooCreated2>` so that events of the old type can be converted into events of the new type
+1. Adapt `CacheDatabaseManager` to handle the new event type
+1. Where necessary, adapt `IDomainIndex`-classes to handle the new event type
+1. Mark the old event type (`FooCreated`) as `[Obsolete]` so that you are warned if your code still uses it
+
+## Stream Migration
+If the desired model change cannot be achieved with event migration, stream migration must be used. A stream migration basically recreates the whole event stream from scratch by reading through all the existing events and emitting new events based on the old ones. For example, if you have a type of event which you want to split into two events, a stream migration is a good way to do that. In contrast to event migrations, a stream migration is only applied once on application startup.
+
+A positive side-effect of stream migrations is that they persist all the event migrations. So after a stream migration has been applied, all obsolete event types up to this point in time can be removed, since the stream no longer contains events of obsolete types (but remember to keep the event types' names such as `FooCreated2` when deleting `FooCreated`).

--- a/HiP-DataStore/Migrations/AboutMigration.md
+++ b/HiP-DataStore/Migrations/AboutMigration.md
@@ -12,7 +12,12 @@ How to implement an event migration:
 1. Where necessary, adapt `IDomainIndex`-classes to handle the new event type
 1. Mark the old event type (`FooCreated`) as `[Obsolete]` so that you are warned if your code still uses it
 
+The main type to support event migration is `PaderbornUniversity.SILab.Hip.DataStore.Model.Events.IMigratable<T>`.
+
 ## Stream Migration
 If the desired model change cannot be achieved with event migration, stream migration must be used. A stream migration basically recreates the whole event stream from scratch by reading through all the existing events and emitting new events based on the old ones. For example, if you have a type of event which you want to split into two events, a stream migration is a good way to do that. In contrast to event migrations, a stream migration is only applied once on application startup.
 
 A positive side-effect of stream migrations is that they persist all the event migrations. So after a stream migration has been applied, all obsolete event types up to this point in time can be removed, since the stream no longer contains events of obsolete types (but remember to keep the event types' names such as `FooCreated2` when deleting `FooCreated`).
+
+The types supporting stream migrations are located in `PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations`.
+The actual migrations should be stored in `PaderbornUniversity.SILab.Hip.DataStore.Migrations`.

--- a/HiP-DataStore/Migrations/PageOrderFeatureMigration.cs
+++ b/HiP-DataStore/Migrations/PageOrderFeatureMigration.cs
@@ -1,0 +1,89 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
+{
+    /// <summary>
+    /// Updates a stream to the new way of organizing exhibit pages, i.e.:
+    /// * Pages no longer reference the containing exhibit
+    /// * Exhibits now store an ordered array of their pages
+    /// * Therefore, ExhibitPageDeleted-events now also store the exhibit ID so that
+    ///   the page can be removed from the exhibit's pages array
+    /// </summary>
+    [StreamMigration(from: 0, to: 1)]
+    public class PageOrderFeatureMigration : IStreamMigration
+    {
+        public async Task MigrateAsync(IStreamMigrationArgs e)
+        {
+            var events = e.GetExistingEvents();
+            var pages = new Dictionary<int, List<int>>(); // stores the page IDs for each exhibit
+            var exhibits = new Dictionary<int, int>(); // stores the exhibit ID for each page
+
+            while (await events.MoveNextAsync())
+            {
+                switch (events.Current)
+                {
+                    case ReferenceAdded ev when ev.SourceType == ResourceType.ExhibitPage && ev.TargetType == ResourceType.Exhibit:
+                        // pages no longer reference the containing exhibit => ignore such references
+                        break;
+
+                    case ExhibitUpdated ev:
+                        // "PUT /Exhibit/{id}" now allows to reorder pages using the new 'pages'-field
+                        // => emit new ExhibitUpdated-events with correctly populated 'pages' array
+                        var pageIds = pages.TryGetValue(ev.Id, out var ids) ? ids : new List<int>();
+                        e.AppendEvent(new ExhibitUpdated
+                        {
+                            Id = ev.Id,
+                            Timestamp = DateTimeOffset.Now,
+                            Properties = new ExhibitUpdateArgs
+                            {
+                                Pages = pageIds,
+                                Description = ev.Properties.Description,
+                                Image = ev.Properties.Image,
+                                Latitude = ev.Properties.Latitude,
+                                Longitude = ev.Properties.Longitude,
+                                Name = ev.Properties.Name,
+                                Status = ev.Properties.Status,
+                                Tags = ev.Properties.Tags
+                            }
+                        });
+                        break;
+
+                    case ExhibitPageCreated2 ev:
+                        // for each page, remember the exhibit containing it (we need it in case ExhibitPageDeleted)
+                        exhibits[ev.Id] = ev.ExhibitId;
+
+                        // ...and add the page ID to the exhibit's pages array
+                        if (pages.TryGetValue(ev.ExhibitId, out var list))
+                            list.Add(ev.Id);
+                        else
+                            pages[ev.ExhibitId] = new List<int> { ev.Id };
+                        break;
+
+                    case ExhibitPageDeleted ev:
+                        // In v0, ExhibitPageDeleted did not store the exhibit ID.
+                        // So we have to find that one out here and emit a new ExhibitPageDeleted event.
+                        var exhibitId = exhibits[ev.Id];
+                        pages[exhibitId].Remove(ev.Id);
+
+                        e.AppendEvent(new ExhibitPageDeleted
+                        {
+                            Id = ev.Id,
+                            ExhibitId = exhibitId
+                        });
+                        break;
+
+                    default:
+                        // all other events remain the same
+                        e.AppendEvent(events.Current);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/HiP-DataStore/Migrations/PageOrderFeatureMigration.cs
+++ b/HiP-DataStore/Migrations/PageOrderFeatureMigration.cs
@@ -63,6 +63,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
                             list.Add(ev.Id);
                         else
                             pages[ev.ExhibitId] = new List<int> { ev.Id };
+
+                        e.AppendEvent(ev);
                         break;
 
                     case ExhibitPageDeleted ev:

--- a/HiP-DataStore/Migrations/PageOrderFeatureMigration.cs
+++ b/HiP-DataStore/Migrations/PageOrderFeatureMigration.cs
@@ -29,9 +29,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
                 switch (events.Current)
                 {
                     case ReferenceAdded ev when ev.SourceType == ResourceType.ExhibitPage && ev.TargetType == ResourceType.Exhibit:
+                    case ReferenceRemoved ev2 when ev2.SourceType == ResourceType.ExhibitPage && ev2.TargetType == ResourceType.Exhibit:
                         // pages no longer reference the containing exhibit => ignore such references
                         break;
-
+                        
                     case ExhibitUpdated ev:
                         // "PUT /Exhibit/{id}" now allows to reorder pages using the new 'pages'-field
                         // => emit new ExhibitUpdated-events with correctly populated 'pages' array


### PR DESCRIPTION
The changes in this PR make it possible to reorder pages using the `pages`-array in a `PUT /Exhibits/{id}`-request. This feature involves quite a lot of modifications because the order of pages was not considered at all until now.

As a byproduct, a stream migration/versioning concept has been implemented to make similar changes in the future easier.