### PR TITLE
Fixed HTTP-route for DELETE /Tags/{id}

### DIFF
--- a/HiP-DataStore/Controllers/TagsController.cs
+++ b/HiP-DataStore/Controllers/TagsController.cs
@@ -183,7 +183,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return NoContent();
         }
 
-        [HttpDelete("id")]
+        [HttpDelete("{id}")]
         [ProducesResponseType(204)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]


### PR DESCRIPTION
Fixed a typo which caused the HTTP-route for tag deletion to be malformed