### PR TITLE
URL to "swagger.json" file is now configurable

### DIFF
--- a/HiP-DataStore/Startup.cs
+++ b/HiP-DataStore/Startup.cs
@@ -62,7 +62,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory, IOptions<CorsConfig> corsConfig)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory,
+            IOptions<CorsConfig> corsConfig, IOptions<EndpointConfig> endpointConfig)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"))
                          .AddDebug();
@@ -72,14 +73,15 @@ namespace PaderbornUniversity.SILab.Hip.DataStore
             app.ApplicationServices.GetService<CacheDatabaseManager>();
 
             // Use CORS (important: must be before app.UseMvc())
-            app.UseCors(builder => {
+            app.UseCors(builder =>
+            {
                 var corsEnvConf = corsConfig.Value.Cors[env.EnvironmentName];
                 builder
                     .WithOrigins(corsEnvConf.Origins)
                     .WithMethods(corsEnvConf.Methods)
                     .WithHeaders(corsEnvConf.Headers)
                     .WithExposedHeaders(corsEnvConf.ExposedHeaders);
-            }); 
+            });
 
             app.UseMvc();
 
@@ -93,9 +95,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore
             // Configure SwaggerUI endpoint
             app.UseSwaggerUI(c =>
             {
-                // TODO: Only a hack, if HiP-Swagger is running, SwaggerUI can be disabled for Production
-                c.SwaggerEndpoint((env.IsDevelopment() ? "/swagger" : "..") +
-                                  "/" + Version + "/swagger.json", Name + Version);
+                var swaggerJsonUrl = string.IsNullOrEmpty(endpointConfig.Value.SwaggerEndpoint)
+                    ? $"/swagger/{Version}/swagger.json"
+                    : endpointConfig.Value.SwaggerEndpoint;
+
+                c.SwaggerEndpoint(swaggerJsonUrl, $"{Name} {Version}");
             });
         }
     }

--- a/HiP-DataStore/Utility/EndpointConfig.cs
+++ b/HiP-DataStore/Utility/EndpointConfig.cs
@@ -31,5 +31,12 @@
         /// For example, you can use different streams for develop and production environments.
         /// </summary>
         public string EventStoreStream { get; set; }
+
+        /// <summary>
+        /// URL that points to the "swagger.json" file. If set, this URL is entered by default
+        /// when accessing the Swagger UI page. If not set, we will try to construct the URL
+        /// automatically which might result in an invalid URL.
+        /// </summary>
+        public string SwaggerEndpoint { get; set; }
     }
 }


### PR DESCRIPTION
Since it seems to be impossible to automatically construct the correct URL to the "swagger.json" file for each environment (develop environment hosted locally, develop environment hosted in our docker cloud, production environment hosted in our docker cloud), I added a property to `EndpointConfig` so that the URL can be configured via `appsettings.json` or environment variables. If no URL is configured, we still try automatic URL construction as a fallback.