### PR TITLE
HIPCMS-735: Remove status limitations when creating/updating entities

### DIFF
--- a/HiP-DataStore/Controllers/ErrorMessages.cs
+++ b/HiP-DataStore/Controllers/ErrorMessages.cs
@@ -4,20 +4,20 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 {
     public static class ErrorMessages
     {
-        public static string ImageNotFoundOrNotPublished(int id) =>
-            $"ID '{id}' does not refer to a published image";
+        public static string ImageNotFound(int id) =>
+            $"No image with ID '{id}' exists";
 
-        public static string AudioNotFoundOrNotPublished(int id) =>
-            $"ID '{id}' does not refer to published audio";
+        public static string AudioNotFound(int id) =>
+            $"No audio with ID '{id}' exists";
 
-        public static string ExhibitNotFoundOrNotPublished(int id) =>
-            $"ID '{id}' does not refer to a published exhibit";
+        public static string ExhibitNotFound(int id) =>
+            $"No exhibit with ID '{id}' exists";
 
-        public static string ExhibitPageNotFoundOrNotPublished(int id) =>
-            $"ID '{id}' does not refer to a published exhibit page";
+        public static string ExhibitPageNotFound(int id) =>
+            $"No page with ID '{id}' exists";
 
-        public static string TagNotFoundOrNotPublished(int id) =>
-            $"ID '{id}' does not refer to a published tag";
+        public static string TagNotFound(int id) =>
+            $"No tag with ID '{id}' exists";
 
         public static string FieldNotAllowedForPageType(string fieldName, PageType pageType) =>
             $"Field '{fieldName}' not allowed for page type '{pageType}'";

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -199,21 +199,21 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (args == null)
                 return;
 
-            // ensure referenced image exists and is published
-            if (args.Image != null && !_mediaIndex.IsPublishedImage(args.Image.Value))
+            // ensure referenced image exists
+            if (args.Image != null && !_mediaIndex.IsImage(args.Image.Value))
                 ModelState.AddModelError(nameof(args.Image),
-                    ErrorMessages.ImageNotFoundOrNotPublished(args.Image.Value));
+                    ErrorMessages.ImageNotFound(args.Image.Value));
 
-            // ensure referenced tags exist and are published
+            // ensure referenced tags exist
             if (args.Tags != null)
             {
                 var invalidIds = args.Tags
-                    .Where(id => _entityIndex.Status(ResourceType.Tag, id) != ContentStatus.Published)
+                    .Where(id => !_entityIndex.Exists(ResourceType.Tag, id))
                     .ToList();
 
                 foreach (var id in invalidIds)
                     ModelState.AddModelError(nameof(args.Tags),
-                        ErrorMessages.TagNotFoundOrNotPublished(id));
+                        ErrorMessages.TagNotFound(id));
             }
         }
         

--- a/HiP-DataStore/Controllers/RoutesController.cs
+++ b/HiP-DataStore/Controllers/RoutesController.cs
@@ -194,38 +194,38 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (args == null)
                 return;
 
-            // ensure referenced image exists and is published
-            if (args.Image != null && !_mediaIndex.IsPublishedImage(args.Image.Value))
+            // ensure referenced image exists
+            if (args.Image != null && !_mediaIndex.IsImage(args.Image.Value))
                 ModelState.AddModelError(nameof(args.Image),
-                    ErrorMessages.ImageNotFoundOrNotPublished(args.Image.Value));
+                    ErrorMessages.ImageNotFound(args.Image.Value));
 
-            // ensure referenced audio exists and is published
-            if (args.Audio != null && !_mediaIndex.IsPublishedAudio(args.Audio.Value))
+            // ensure referenced audio exists
+            if (args.Audio != null && !_mediaIndex.IsAudio(args.Audio.Value))
                 ModelState.AddModelError(nameof(args.Audio),
-                    ErrorMessages.AudioNotFoundOrNotPublished(args.Audio.Value));
+                    ErrorMessages.AudioNotFound(args.Audio.Value));
 
-            // ensure referenced exhibits exist and are published
+            // ensure referenced exhibits exist
             if (args.Exhibits != null)
             {
                 var invalidIds = args.Exhibits
-                    .Where(id => _entityIndex.Status(ResourceType.Exhibit, id) != ContentStatus.Published)
+                    .Where(id => !_entityIndex.Exists(ResourceType.Exhibit, id))
                     .ToList();
 
                 foreach (var id in invalidIds)
                     ModelState.AddModelError(nameof(args.Exhibits),
-                        ErrorMessages.ExhibitNotFoundOrNotPublished(id));
+                        ErrorMessages.ExhibitNotFound(id));
             }
 
-            // ensure referenced tags exist and are published
+            // ensure referenced tags exist
             if (args.Tags != null)
             {
                 var invalidIds = args.Tags
-                    .Where(id => _entityIndex.Status(ResourceType.Tag, id) != ContentStatus.Published)
+                    .Where(id => !_entityIndex.Exists(ResourceType.Tag, id))
                     .ToList();
 
                 foreach (var id in invalidIds)
                     ModelState.AddModelError(nameof(args.Tags),
-                        ErrorMessages.TagNotFoundOrNotPublished(id));
+                        ErrorMessages.TagNotFound(id));
             }
         }
 

--- a/HiP-DataStore/Controllers/TagsController.cs
+++ b/HiP-DataStore/Controllers/TagsController.cs
@@ -232,9 +232,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (args == null)
                 return;
 
-            if (args.Image != null && !_mediaIndex.IsPublishedImage(args.Image.Value))
+            // ensure referenced image exists
+            if (args.Image != null && !_mediaIndex.IsImage(args.Image.Value))
                 ModelState.AddModelError(nameof(args.Image),
-                    ErrorMessages.ImageNotFoundOrNotPublished(args.Image.Value));
+                    ErrorMessages.ImageNotFound(args.Image.Value));
         }
     }
 

--- a/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
+++ b/HiP-DataStore/Core/WriteModel/Commands/ExhibitPageCommands.cs
@@ -39,34 +39,34 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel.Commands
             if (!exhibitPagesConfig.IsFontFamilyValid(args.FontFamily))
                 addValidationError(nameof(args.FontFamily), $"Font family must be null/unspecified (which defaults to {exhibitPagesConfig.DefaultFontFamily}) or one of the following: {string.Join(", ", exhibitPagesConfig.FontFamilies)}");
 
-            // ensure referenced image exists and is published
-            if (args.Image != null && !mediaIndex.IsPublishedImage(args.Image.Value))
+            // ensure referenced image exists
+            if (args.Image != null && !mediaIndex.IsImage(args.Image.Value))
                 addValidationError(nameof(args.Image),
-                    ErrorMessages.ImageNotFoundOrNotPublished(args.Image.Value));
+                    ErrorMessages.ImageNotFound(args.Image.Value));
 
-            // ensure referenced images exist and are published
+            // ensure referenced slider page images exist
             if (args.Images != null)
             {
                 var invalidIds = args.Images
                     .Select(img => img.Image)
-                    .Where(id => !mediaIndex.IsPublishedImage(id))
+                    .Where(id => !mediaIndex.IsImage(id))
                     .ToList();
 
                 foreach (var id in invalidIds)
                     addValidationError(nameof(args.Images),
-                        ErrorMessages.ImageNotFoundOrNotPublished(id));
+                        ErrorMessages.ImageNotFound(id));
             }
 
-            // ensure referenced additional info pages exist and are published
+            // ensure referenced additional info pages exist
             if (args.AdditionalInformationPages != null)
             {
                 var invalidIds = args.AdditionalInformationPages
-                    .Where(id => entityIndex.Status(ResourceType.ExhibitPage, id) != ContentStatus.Published)
+                    .Where(id => !entityIndex.Exists(ResourceType.ExhibitPage, id))
                     .ToList();
 
                 foreach (var id in invalidIds)
                     addValidationError(nameof(args.AdditionalInformationPages),
-                        ErrorMessages.ExhibitPageNotFoundOrNotPublished(id));
+                        ErrorMessages.ExhibitPageNotFound(id));
             }
         }
 

--- a/HiP-DataStore/Core/WriteModel/MediaIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/MediaIndex.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;

--- a/HiP-DataStore/Core/WriteModel/MediaIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/MediaIndex.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
@@ -13,25 +14,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         private readonly Dictionary<int, MediaInfo> _media = new Dictionary<int, MediaInfo>();
         private readonly object _lockObject = new object();
 
-        public bool IsPublishedImage(int id)
-        {
-            lock (_lockObject)
-            {
-                return _media.TryGetValue(id, out var info) &&
-                info.Status == ContentStatus.Published &&
-                info.Type == MediaType.Image;
-            }
-        }
-
-        public bool IsPublishedAudio(int id)
-        {
-            lock (_lockObject)
-            {
-                return _media.TryGetValue(id, out var info) &&
-                info.Status == ContentStatus.Published &&
-                info.Type == MediaType.Audio;
-            }
-        }
         public MediaType? GetMediaType(int id)
         {
             lock (_lockObject)
@@ -55,7 +37,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         {
             lock (_lockObject)
             {
-                return _media.ContainsKey(id) && _media[id].Type == MediaType.Image;
+                return _media.TryGetValue(id, out var info) && info.Type == MediaType.Image;
             }
         }
 
@@ -63,7 +45,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         {
             lock (_lockObject)
             {
-                return _media.ContainsKey(id) && _media[id].Type == MediaType.Audio;
+                return _media.TryGetValue(id, out var info) && info.Type == MediaType.Audio;
             }
         }
 


### PR DESCRIPTION
When creating or updating exhibits, routes etc., the requirement for referenced entities to be published is now removed. For example, it is now possible to create and publish an exhibit that references a page with state "Draft".
