### PR TITLE
HIPCMS-722: Implemented GET-methods for obtaining reference info

### DIFF
--- a/HiP-DataStore.Model/Rest/ReferenceInfoResult.cs
+++ b/HiP-DataStore.Model/Rest/ReferenceInfoResult.cs
@@ -10,14 +10,14 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
     public class ReferenceInfoResult
     {
         /// <summary>
-        /// The resources referenced by the resource of interest.
+        /// The resources referenced by the current resource.
         /// </summary>
-        public IReadOnlyCollection<ReferenceInfo> Referencees { get; set; }
+        public IReadOnlyCollection<ReferenceInfo> OutgoingReferences { get; set; }
 
         /// <summary>
-        /// The resources referencing the resource of interest.
+        /// The resources referencing the current resource.
         /// </summary>
-        public IReadOnlyCollection<ReferenceInfo> Referencers { get; set; }
+        public IReadOnlyCollection<ReferenceInfo> IncomingReferences { get; set; }
 
         public class ReferenceInfo
         {

--- a/HiP-DataStore.Model/Rest/ReferenceInfoResult.cs
+++ b/HiP-DataStore.Model/Rest/ReferenceInfoResult.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
+{
+    /// <summary>
+    /// For a particular resource, a <see cref="ReferenceInfoResult"/> provides information about
+    /// (1) which other resources it references (or "uses"), and
+    /// (2) which other resources are referencing (or "using") it
+    /// </summary>
+    public class ReferenceInfoResult
+    {
+        /// <summary>
+        /// The resources referenced by the resource of interest.
+        /// </summary>
+        public IReadOnlyCollection<ReferenceInfo> Referencees { get; set; }
+
+        /// <summary>
+        /// The resources referencing the resource of interest.
+        /// </summary>
+        public IReadOnlyCollection<ReferenceInfo> Referencers { get; set; }
+
+        public class ReferenceInfo
+        {
+            public string Type { get; set; }
+
+            public IReadOnlyCollection<int> Ids { get; set; }
+        }
+    }
+}

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -228,6 +228,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpGet("Pages/{id}/Refs")]
         [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         public IActionResult GetReferenceInfo(int id)
         {

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -226,6 +226,17 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return NoContent();
         }
 
+        [HttpGet("Pages/{id}/Refs")]
+        [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetReferenceInfo(int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            return ReferenceInfoHelper.GetReferenceInfo(ResourceType.ExhibitPage, id, _entityIndex, _referencesIndex);
+        }
+
 
         private IActionResult QueryExhibitPages(IQueryable<ExhibitPage> allPages, ExhibitPageQueryArgs args)
         {

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -193,6 +193,17 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return NoContent();
         }
 
+        [HttpGet("{id}/Refs")]
+        [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetReferenceInfo(int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            return ReferenceInfoHelper.GetReferenceInfo(ResourceType.Exhibit, id, _entityIndex, _referencesIndex);
+        }
+
 
         private void ValidateExhibitArgs(ExhibitArgs args)
         {

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -195,6 +195,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpGet("{id}/Refs")]
         [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         public IActionResult GetReferenceInfo(int id)
         {

--- a/HiP-DataStore/Controllers/MediaController.cs
+++ b/HiP-DataStore/Controllers/MediaController.cs
@@ -269,6 +269,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpGet("{id}/Refs")]
         [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         public IActionResult GetReferenceInfo(int id)
         {

--- a/HiP-DataStore/Controllers/MediaController.cs
+++ b/HiP-DataStore/Controllers/MediaController.cs
@@ -162,11 +162,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 return BadRequest(ErrorMessages.ResourceInUse);
 
             // Remove file
-            string directoryPath = Path.GetDirectoryName(_mediaIndex.GetFilePath(id)); 
+            string directoryPath = Path.GetDirectoryName(_mediaIndex.GetFilePath(id));
             if (directoryPath != null && System.IO.Directory.Exists(directoryPath))
                 Directory.Delete(directoryPath, true);
 
-        
+
 
             var ev = new MediaDeleted { Id = id };
             await _eventStore.AppendEventAsync(ev);
@@ -265,6 +265,17 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
             await _eventStore.AppendEventAsync(ev);
             return StatusCode(204);
+        }
+
+        [HttpGet("{id}/Refs")]
+        [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetReferenceInfo(int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            return ReferenceInfoHelper.GetReferenceInfo(ResourceType.Media, id, _entityIndex, _referencesIndex);
         }
     }
 }

--- a/HiP-DataStore/Controllers/MediaController.cs
+++ b/HiP-DataStore/Controllers/MediaController.cs
@@ -166,8 +166,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (directoryPath != null && System.IO.Directory.Exists(directoryPath))
                 Directory.Delete(directoryPath, true);
 
-
-
             var ev = new MediaDeleted { Id = id };
             await _eventStore.AppendEventAsync(ev);
             return StatusCode(204);
@@ -225,7 +223,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
-
 
             if (!_entityIndex.Exists(ResourceType.Media, id))
                 return NotFound();

--- a/HiP-DataStore/Controllers/ReferenceInfoHelper.cs
+++ b/HiP-DataStore/Controllers/ReferenceInfoHelper.cs
@@ -26,8 +26,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
             return new OkObjectResult(new ReferenceInfoResult
             {
-                Referencees = TransformToResult(referencesIndex.ReferencesOf(type, id)),
-                Referencers = TransformToResult(referencesIndex.ReferencesTo(type, id))
+                OutgoingReferences = TransformToResult(referencesIndex.ReferencesOf(type, id)),
+                IncomingReferences = TransformToResult(referencesIndex.ReferencesTo(type, id))
             });
 
             IReadOnlyCollection<ReferenceInfoResult.ReferenceInfo> TransformToResult(IEnumerable<ReferencesIndex.Entry> refs)

--- a/HiP-DataStore/Controllers/ReferenceInfoHelper.cs
+++ b/HiP-DataStore/Controllers/ReferenceInfoHelper.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
+{
+    /// <summary>
+    /// Provides helper methods that simplify implementation of GET-methods that return reference info for resources.
+    /// </summary>
+    public static class ReferenceInfoHelper
+    {
+        /// <summary>
+        /// Obtains reference information for a resource.
+        /// </summary>
+        /// <returns>
+        /// "200 Ok" with reference info if successful.
+        /// "404 Not Found" if no resource with the specified type and ID exists.
+        /// </returns>
+        public static IActionResult GetReferenceInfo(ResourceType type, int id, EntityIndex entityIndex, ReferencesIndex referencesIndex)
+        {
+            if (!entityIndex.Exists(type, id))
+                return new NotFoundResult();
+
+            return new OkObjectResult(new ReferenceInfoResult
+            {
+                Referencees = TransformToResult(referencesIndex.ReferencesOf(type, id)),
+                Referencers = TransformToResult(referencesIndex.ReferencesTo(type, id))
+            });
+
+            IReadOnlyCollection<ReferenceInfoResult.ReferenceInfo> TransformToResult(IEnumerable<ReferencesIndex.Entry> refs)
+            {
+                return refs
+                    .GroupBy(entry => entry.Type)
+                    .Select(group => new ReferenceInfoResult.ReferenceInfo
+                    {
+                        Type = group.Key.Name,
+                        Ids = group.Select(e => e.Id).OrderBy(i => i).ToList()
+                    })
+                    .OrderBy(group => group.Type)
+                    .ToList();
+            }
+        }
+    }
+}

--- a/HiP-DataStore/Controllers/RoutesController.cs
+++ b/HiP-DataStore/Controllers/RoutesController.cs
@@ -190,6 +190,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpGet("{id}/Refs")]
         [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         public IActionResult GetReferenceInfo(int id)
         {

--- a/HiP-DataStore/Controllers/RoutesController.cs
+++ b/HiP-DataStore/Controllers/RoutesController.cs
@@ -188,6 +188,17 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return NoContent();
         }
 
+        [HttpGet("{id}/Refs")]
+        [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetReferenceInfo(int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            return ReferenceInfoHelper.GetReferenceInfo(ResourceType.Route, id, _entityIndex, _referencesIndex);
+        }
+
 
         private void ValidateRouteArgs(RouteArgs args)
         {

--- a/HiP-DataStore/Controllers/TagsController.cs
+++ b/HiP-DataStore/Controllers/TagsController.cs
@@ -1,16 +1,16 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using MongoDB.Driver;
 using PaderbornUniversity.SILab.Hip.DataStore.Core;
 using PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel;
 using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using MongoDB.Driver;
 using Tag = PaderbornUniversity.SILab.Hip.DataStore.Model.Entity.Tag;
-using PaderbornUniversity.SILab.Hip.DataStore.Model;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 {
@@ -224,6 +224,17 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             }
 
             return NoContent();
+        }
+
+        [HttpGet("{id}/Refs")]
+        [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult GetReferenceInfo(int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            return ReferenceInfoHelper.GetReferenceInfo(ResourceType.Tag, id, _entityIndex, _referencesIndex);
         }
 
 

--- a/HiP-DataStore/Controllers/TagsController.cs
+++ b/HiP-DataStore/Controllers/TagsController.cs
@@ -228,6 +228,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpGet("{id}/Refs")]
         [ProducesResponseType(typeof(ReferenceInfoResult), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         public IActionResult GetReferenceInfo(int id)
         {


### PR DESCRIPTION
New methods:
* `GET /api/Exhibits/{id}/Refs`
* `GET /api/Exhibits/Pages/{id}/Refs`
* `GET /api/Media/{id}/Refs`
* `GET /api/Routes/{id}/Refs`
* `GET /api/Tags/{id}/Refs`

The following shows a sample response from one of the methods:
```JSON
{
  "outgoingReferences": [
    {
      "type": "Media",
      "ids": [ 14, 20, 21 ]
    }
  ],
  "incomingReferences": [
    {
      "type": "Exhibit",
      "ids": [ 3 ]
    },
    {
      "type": "ExhibitPage",
      "ids": [ 1, 18 ]
    }
  ]
}
```