### PR TITLE
Fixed bugs regarding page order

### DIFF
--- a/HiP-DataStore.Model/DocRefList.cs
+++ b/HiP-DataStore.Model/DocRefList.cs
@@ -17,7 +17,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model
     public class DocRefList<T> : DocRefBase//, ICollection<BsonValue>
     {
         [BsonElement]
-        public HashSet<BsonValue> Ids { get; private set; } = new HashSet<BsonValue>();
+        public OrderedSet<BsonValue> Ids { get; private set; } = new OrderedSet<BsonValue>();
 
         public int Count => Ids.Count;
 
@@ -34,7 +34,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model
             if (ids == null)
                 throw new ArgumentNullException(nameof(ids));
 
-            Ids = new HashSet<BsonValue>(ids);
+            Ids = new OrderedSet<BsonValue>(ids);
         }
 
         public bool Add(BsonValue id) => Ids.Add(id);

--- a/HiP-DataStore.Model/OrderedSet.cs
+++ b/HiP-DataStore.Model/OrderedSet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model
 {
@@ -10,15 +11,27 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model
     public class OrderedSet<T> : ICollection<T>
     {
         private readonly IDictionary<T, LinkedListNode<T>> _dictionary;
-        private readonly LinkedList<T> _linkedList = new LinkedList<T>();
+        private readonly LinkedList<T> _linkedList;
 
         public OrderedSet() : this(EqualityComparer<T>.Default)
         {
         }
 
-        public OrderedSet(IEqualityComparer<T> comparer)
+        public OrderedSet(IEnumerable<T> items) : this(items, EqualityComparer<T>.Default)
+        {
+        }
+
+        public OrderedSet(IEqualityComparer<T> comparer) : this(Enumerable.Empty<T>(), comparer)
+        {
+        }
+
+        public OrderedSet(IEnumerable<T> items, IEqualityComparer<T> comparer)
         {
             _dictionary = new Dictionary<T, LinkedListNode<T>>(comparer);
+            _linkedList = new LinkedList<T>();
+
+            foreach (var item in items)
+                Add(item);
         }
 
         public int Count => _dictionary.Count;

--- a/HiP-DataStore.Model/OrderedSet.cs
+++ b/HiP-DataStore.Model/OrderedSet.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model
+{
+    /// <summary>
+    /// A hash set that preserves insertion order while still allowing basic set operations in O(1).
+    /// Adapted from https://www.codeproject.com/Articles/627085/HashSet-that-Preserves-Insertion-Order-or-NET.
+    /// </summary>
+    public class OrderedSet<T> : ICollection<T>
+    {
+        private readonly IDictionary<T, LinkedListNode<T>> _dictionary;
+        private readonly LinkedList<T> _linkedList = new LinkedList<T>();
+
+        public OrderedSet() : this(EqualityComparer<T>.Default)
+        {
+        }
+
+        public OrderedSet(IEqualityComparer<T> comparer)
+        {
+            _dictionary = new Dictionary<T, LinkedListNode<T>>(comparer);
+        }
+
+        public int Count => _dictionary.Count;
+
+        public virtual bool IsReadOnly => false;
+
+        void ICollection<T>.Add(T item) => Add(item);
+
+        public bool Add(T item)
+        {
+            if (_dictionary.ContainsKey(item))
+                return false;
+
+            var node = _linkedList.AddLast(item);
+            _dictionary.Add(item, node);
+            return true;
+        }
+
+        public void Clear()
+        {
+            _linkedList.Clear();
+            _dictionary.Clear();
+        }
+
+        public bool Remove(T item)
+        {
+            if (!_dictionary.TryGetValue(item, out var node))
+                return false;
+
+            _dictionary.Remove(item);
+            _linkedList.Remove(node);
+            return true;
+        }
+
+        public IEnumerator<T> GetEnumerator() => _linkedList.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public bool Contains(T item) => _dictionary.ContainsKey(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _linkedList.CopyTo(array, arrayIndex);
+    }
+}

--- a/HiP-DataStore/Core/DocRefExtensions.cs
+++ b/HiP-DataStore/Core/DocRefExtensions.cs
@@ -2,6 +2,7 @@
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core
 {
@@ -70,9 +71,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
         /// </summary>
         public static IReadOnlyCollection<T> LoadAll<T>(this DocRefList<T> docRef, IMongoCollection<T> collection)
         {
-            return collection
-                .Find(Builders<T>.Filter.In("_id", docRef.Ids))
+            // Less efficient approach, preserves ordering
+            return docRef.Ids
+                .Select(id => collection.Find(Builders<T>.Filter.Eq("_id", id)).First())
                 .ToList();
+
+            // Simple, efficient approach (unfortunately doesn't preserve ordering):
+            // return collection.Find(Builders<T>.Filter.In("_id", docRef.Ids)).ToList();
         }
     }
 }


### PR DESCRIPTION
Problem: When modifying the order of pages of an exhibit (or additional information pages of a page) via a PUT request, the order of pages returned by GET requests might be inconsistent with the specified order.

There were two issues here:
1. `DocRefList<T>` stores IDs in a `HashSet<T>` which does not preserve insertion order. Thus, in the MongoDB cache database the order of page IDs might already be mixed up
1. `DocRefExtensions.LoadAll(...)` retrieves objects using the filter "take all objects of which the ID is in the DocRefList's set of IDs" - again this does not preserve order

Fixes:
1. `DocRefList<T>.Ids` is now an `OrderedSet<T>`
1. `DocRefExtensions.LoadAll(...)` now iterates over the set of IDs and queries the database separately for each ID (which might be less efficient but solves the problem)