### PR TITLE
HIPCMS-802: Filtering by page type

### DIFF
--- a/HiP-DataStore.Model/Rest/ExhibitPageQueryArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageQueryArgs.cs
@@ -2,5 +2,9 @@
 {
     public class ExhibitPageQueryArgs : QueryArgs
     {
+        /// <summary>
+        /// If not null, only pages of the specified type are returned.
+        /// </summary>
+        public PageType? Type { get; set; }
     }
 }

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -284,6 +284,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                         x.Title.ToLower().Contains(args.Query.ToLower()) ||
                         x.Text.ToLower().Contains(args.Query.ToLower()) ||
                         x.Description.ToLower().Contains(args.Query.ToLower()))
+                    .FilterIf(args.Type != null, x => x.Type == args.Type)
                     .Sort(args.OrderBy,
                         ("id", x => x.Id),
                         ("title", x => x.Title),


### PR DESCRIPTION
This PR implements the ability to filter exhibit pages by their type. To achieve this, a new query parameter `type` is introduced.