### PR TITLE
Revert "HIPCMS-761: Moved event sourcing fundamentals to HiP-EventStoreLib"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk
+FROM microsoft/dotnet:1.1.1-sdk
 
 RUN apt-get update && apt-get install make gcc -y
 

--- a/HiP-DataStore.Model/DocRef.cs
+++ b/HiP-DataStore.Model/DocRef.cs
@@ -1,0 +1,34 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model
+{
+
+    /// <summary>
+    /// A strongly-typed reference to another document in a Mongo database.
+    /// </summary>
+    /// <remarks>
+    /// DocRefs are for internal use, they should not be exposed via the public REST interface.
+    /// </remarks>
+    public class DocRef<T> : DocRefBase
+    {
+        /// <summary>
+        /// ID of the referenced object.
+        /// </summary>
+        public BsonValue Id { get; set; }
+
+        public DocRef(string collection = null, string database = null) : base(collection, database)
+        {
+        }
+
+        [BsonConstructor]
+        public DocRef(BsonValue id, string collection = null, string database = null) : base(collection, database)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+        }
+
+        public override string ToString() =>
+            $"{Id} (collection: '{Collection ?? "<unspecified>"}', database: '{Database ?? "<unspecified>"}')";
+    }
+}

--- a/HiP-DataStore.Model/DocRefBase.cs
+++ b/HiP-DataStore.Model/DocRefBase.cs
@@ -1,0 +1,34 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model
+{
+    /// <summary>
+    /// Base class for <see cref="DocRef{T}"/> and <see cref="DocRefList{T}"/>.
+    /// </summary>
+    public abstract class DocRefBase
+    {
+        /// <summary>
+        /// The name of the collection where the referenced document is. This property is optional:
+        /// If not set, the referenced document is assumed to be in the same collection as the referencing document.
+        /// </summary>
+        [BsonElement]
+        public string Collection { get; private set; }
+
+        /// <summary>
+        /// The name of the database where the referenced document is. This property is optional:
+        /// If not set, the referenced document is assumed to be in the same database as the referencing document.
+        /// </summary>
+        [BsonElement]
+        public string Database { get; private set; }
+
+        protected DocRefBase()
+        {
+        }
+
+        protected DocRefBase(string collection, string database)
+        {
+            Collection = collection;
+            Database = database;
+        }
+    }
+}

--- a/HiP-DataStore.Model/DocRefList.cs
+++ b/HiP-DataStore.Model/DocRefList.cs
@@ -1,0 +1,56 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model
+{
+    /// <summary>
+    /// A strongly-typed reference to multiple other documents in a Mongo database.
+    /// </summary>
+    /// <remarks>
+    /// Unfortunately this type cannot implement <see cref="IEnumerable{BsonValue}"/> or any derived type
+    /// because the BSON serializer then serializes objects of this type as array, forgetting about the fields
+    /// 'Collection' and 'Database'.
+    /// </remarks>
+    public class DocRefList<T> : DocRefBase//, ICollection<BsonValue>
+    {
+        [BsonElement]
+        public OrderedSet<BsonValue> Ids { get; private set; } = new OrderedSet<BsonValue>();
+
+        public int Count => Ids.Count;
+
+        public DocRefList()
+        {
+        }
+
+        public DocRefList(string collection = null, string database = null) : base(collection, database)
+        {
+        }
+
+        public DocRefList(IEnumerable<BsonValue> ids, string collection = null, string database = null) : base(collection, database)
+        {
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+
+            Ids = new OrderedSet<BsonValue>(ids);
+        }
+
+        public bool Add(BsonValue id) => Ids.Add(id);
+
+        public void Add(IEnumerable<BsonValue> ids)
+        {
+            foreach (var id in ids ?? Enumerable.Empty<BsonValue>())
+                Ids.Add(id);
+        }
+
+        public bool Remove(BsonValue id) => Ids.Remove(id);
+
+        public void Clear() => Ids.Clear();
+
+        public bool Contains(BsonValue id) => Ids.Contains(id);
+
+        public IEnumerator<BsonValue> GetEnumerator() => Ids.GetEnumerator();
+    }
+}

--- a/HiP-DataStore.Model/Entity/ContentBase.cs
+++ b/HiP-DataStore.Model/Entity/ContentBase.cs
@@ -1,5 +1,4 @@
-﻿using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity

--- a/HiP-DataStore.Model/Entity/Exhibit.cs
+++ b/HiP-DataStore.Model/Entity/Exhibit.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity

--- a/HiP-DataStore.Model/Entity/ExhibitPage.cs
+++ b/HiP-DataStore.Model/Entity/ExhibitPage.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/HiP-DataStore.Model/Entity/Route.cs
+++ b/HiP-DataStore.Model/Entity/Route.cs
@@ -2,7 +2,6 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {

--- a/HiP-DataStore.Model/Entity/SliderPageImage.cs
+++ b/HiP-DataStore.Model/Entity/SliderPageImage.cs
@@ -1,6 +1,5 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {

--- a/HiP-DataStore.Model/Entity/Tag.cs
+++ b/HiP-DataStore.Model/Entity/Tag.cs
@@ -1,6 +1,5 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 {

--- a/HiP-DataStore.Model/Events/ExhibitPageCreated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageCreated.cs
@@ -1,5 +1,4 @@
 ﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
+++ b/HiP-DataStore.Model/Events/ExhibitPageUpdated.cs
@@ -1,5 +1,4 @@
 ﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/HiP-DataStore.Model/Events/IEvent.cs
+++ b/HiP-DataStore.Model/Events/IEvent.cs
@@ -1,9 +1,15 @@
-﻿using PaderbornUniversity.SILab.Hip.EventSourcing;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
+    /// <summary>
+    /// Marker interface for events.
+    /// </summary>
+    public interface IEvent
+    {
+    }
+
     /// <summary>
     /// An event for simple create, update and delete operations.
     /// </summary>

--- a/HiP-DataStore.Model/Events/IMigratable.cs
+++ b/HiP-DataStore.Model/Events/IMigratable.cs
@@ -1,0 +1,31 @@
+﻿namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
+{
+    /// <summary>
+    /// Types implementing this interface can migrate objects to a newer version of the type.
+    /// This is used for example to transform old events from the event log to the latest version.
+    /// </summary>
+    public interface IMigratable<out T>
+    {
+        /// <summary>
+        /// Transforms this object to an object of a newer version of the (logically) same type.
+        /// </summary>
+        /// <returns></returns>
+        T Migrate();
+    }
+
+    public static class MigratableExtensions
+    {
+        /// <summary>
+        /// Applies all possible migrations in order to update an object to the latest version of its type.
+        /// If the specified object does not support migration, it is returned as is.
+        /// </summary>
+        /// <typeparam name="TBase">The base class or interface all versions of the type have in common</typeparam>
+        public static TBase MigrateToLatestVersion<TBase>(this TBase obj)
+        {
+            while (obj is IMigratable<TBase> o)
+                obj = o.Migrate();
+
+            return obj;
+        }
+    }
+}

--- a/HiP-DataStore.Model/Events/ReferenceEvents.cs
+++ b/HiP-DataStore.Model/Events/ReferenceEvents.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Events
 {
     public abstract class ReferenceEventBase : IEvent

--- a/HiP-DataStore.Model/HiP-DataStore.Model.csproj
+++ b/HiP-DataStore.Model/HiP-DataStore.Model.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.DataStore.Model</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="HiP-EventStoreLib" Version="0.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.4.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/HiP-DataStore.Model/OrderedSet.cs
+++ b/HiP-DataStore.Model/OrderedSet.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Model
+{
+    /// <summary>
+    /// A hash set that preserves insertion order while still allowing basic set operations in O(1).
+    /// Adapted from https://www.codeproject.com/Articles/627085/HashSet-that-Preserves-Insertion-Order-or-NET.
+    /// </summary>
+    public class OrderedSet<T> : ICollection<T>
+    {
+        private readonly IDictionary<T, LinkedListNode<T>> _dictionary;
+        private readonly LinkedList<T> _linkedList;
+
+        public OrderedSet() : this(EqualityComparer<T>.Default)
+        {
+        }
+
+        public OrderedSet(IEnumerable<T> items) : this(items, EqualityComparer<T>.Default)
+        {
+        }
+
+        public OrderedSet(IEqualityComparer<T> comparer) : this(Enumerable.Empty<T>(), comparer)
+        {
+        }
+
+        public OrderedSet(IEnumerable<T> items, IEqualityComparer<T> comparer)
+        {
+            _dictionary = new Dictionary<T, LinkedListNode<T>>(comparer);
+            _linkedList = new LinkedList<T>();
+
+            foreach (var item in items)
+                Add(item);
+        }
+
+        public int Count => _dictionary.Count;
+
+        public virtual bool IsReadOnly => false;
+
+        void ICollection<T>.Add(T item) => Add(item);
+
+        public bool Add(T item)
+        {
+            if (_dictionary.ContainsKey(item))
+                return false;
+
+            var node = _linkedList.AddLast(item);
+            _dictionary.Add(item, node);
+            return true;
+        }
+
+        public void Clear()
+        {
+            _linkedList.Clear();
+            _dictionary.Clear();
+        }
+
+        public bool Remove(T item)
+        {
+            if (!_dictionary.TryGetValue(item, out var node))
+                return false;
+
+            _dictionary.Remove(item);
+            _linkedList.Remove(node);
+            return true;
+        }
+
+        public IEnumerator<T> GetEnumerator() => _linkedList.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public bool Contains(T item) => _dictionary.ContainsKey(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _linkedList.CopyTo(array, arrayIndex);
+    }
+}

--- a/HiP-DataStore.Model/Rest/ExhibitPageArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitPageArgs.cs
@@ -1,4 +1,4 @@
-﻿using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/HiP-DataStore.Tests/ControllerTests/TagsControllerTest.cs
+++ b/HiP-DataStore.Tests/ControllerTests/TagsControllerTest.cs
@@ -1,17 +1,18 @@
-﻿using MyTested.AspNetCore.Mvc;
+﻿using System;
+using MyTested.AspNetCore.Mvc;
 using PaderbornUniversity.SILab.Hip.DataStore.Controllers;
 using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-using System;
 using Xunit;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Tests.ControllerTests
 {
     public class TagsControllerTest
     {
-        private TagIndex _tagIndex => MvcTestContext.Services.GetService<InMemoryCache>().Index<TagIndex>();
+        private TagIndex _tagIndex => MvcTestContext.Services.GetService<IEnumerable<IDomainIndex>>().OfType<TagIndex>().First();
         private TagArgs TagArgs { get; set; }
 
         public TagsControllerTest()
@@ -110,7 +111,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Tests.ControllerTests
 
             MyMvc
                 .Controller<TagsController>()
-                .Calling(c => c.DeleteByIdAsync(tagId))
+                .Calling(c => c.DeleteById(tagId))
                 .ShouldReturn()
                 .NoContent();
         }
@@ -161,7 +162,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Tests.ControllerTests
 
             MyMvc
                 .Controller<TagsController>()
-                .Calling(c => c.UpdateByIdAsync(1, TagArgs))
+                .Calling(c => c.UpdateById(1, TagArgs))
                 .ShouldReturn()
                 .NoContent();
         }
@@ -176,7 +177,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Tests.ControllerTests
 
             MyMvc
                 .Controller<TagsController>()
-                .Calling(c => c.UpdateByIdAsync(0, TagArgs))
+                .Calling(c => c.UpdateById(0, TagArgs))
                 .ShouldReturn()
                 .NotFound();
         }
@@ -191,7 +192,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Tests.ControllerTests
 
             MyMvc
                 .Controller<TagsController>()
-                .Calling(c => c.UpdateByIdAsync(1, tagArgs))
+                .Calling(c => c.UpdateById(1, tagArgs))
                 .ShouldReturn()
                 .BadRequest();
         }
@@ -204,7 +205,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Tests.ControllerTests
         {
             MyMvc
                 .Controller<TagsController>()
-                .Calling(c => c.DeleteByIdAsync(11))
+                .Calling(c => c.DeleteById(11))
                 .ShouldReturn()
                 .NotFound();
         }

--- a/HiP-DataStore.Tests/HiP-DataStore.Tests.csproj
+++ b/HiP-DataStore.Tests/HiP-DataStore.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.DataStore.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.2" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MyTested.AspNetCore.Mvc.Universe" Version="1.1.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/HiP-DataStore.Tests/TestStartup.cs
+++ b/HiP-DataStore.Tests/TestStartup.cs
@@ -10,7 +10,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel;
 using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
 using PaderbornUniversity.SILab.Hip.DataStore.Utility;
 using Microsoft.Extensions.Options;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Tests
 {
@@ -36,14 +35,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Tests
                 .Configure<UploadFilesConfig>(Configuration.GetSection("UploadingFiles"))
                 .Configure<ExhibitPagesConfig>(Configuration.GetSection("ExhibitPages"))
                 .Configure<CorsConfig>(Configuration);
-
+            
             // Add framework services
             services.AddMvc();
 
             services
                 .AddSingleton<EventStoreClient>()
                 .AddSingleton<CacheDatabaseManager>()
-                .AddSingleton<InMemoryCache>()
                 .AddSingleton<IDomainIndex, MediaIndex>()
                 .AddSingleton<IDomainIndex, EntityIndex>()
                 .AddSingleton<IDomainIndex, ReferencesIndex>()

--- a/HiP-DataStore.sln
+++ b/HiP-DataStore.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HiP-DataStore", "HiP-DataStore\HiP-DataStore.csproj", "{AA345286-8B3C-48B3-8E3A-F0D0571A9091}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HiP-DataStore.Model", "HiP-DataStore.Model\HiP-DataStore.Model.csproj", "{974D45A5-D139-4838-B766-9349E7C20CE4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HiP-DataStore.Tests", "HiP-DataStore.Tests\HiP-DataStore.Tests.csproj", "{2168A290-1074-4577-8F33-3872B39B02ED}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiP-DataStore.Tests", "HiP-DataStore.Tests\HiP-DataStore.Tests.csproj", "{2168A290-1074-4577-8F33-3872B39B02ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -9,8 +9,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
 using PaderbornUniversity.SILab.Hip.DataStore.Utility;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,15 +33,15 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             IOptions<ExhibitPagesConfig> exhibitPagesConfig,
             EventStoreClient eventStore,
             CacheDatabaseManager db,
-            InMemoryCache cache)
+            IEnumerable<IDomainIndex> indices)
         {
             _exhibitPagesConfig = exhibitPagesConfig;
             _eventStore = eventStore;
             _db = db;
-            _mediaIndex = cache.Index<MediaIndex>();
-            _entityIndex = cache.Index<EntityIndex>();
-            _referencesIndex = cache.Index<ReferencesIndex>();
-            _exhibitPageIndex = cache.Index<ExhibitPageIndex>();
+            _mediaIndex = indices.OfType<MediaIndex>().First();
+            _entityIndex = indices.OfType<EntityIndex>().First();
+            _referencesIndex = indices.OfType<ReferencesIndex>().First();
+            _exhibitPageIndex = indices.OfType<ExhibitPageIndex>().First();
         }
 
         [HttpGet("Pages/ids")]
@@ -126,7 +124,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
             if (exhibit == null)
                 return NotFound();
-
+            
             var query = exhibit.Pages.LoadAll(_db.Database).AsQueryable();
 
             return QueryExhibitPages(query, args);
@@ -187,6 +185,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             // validation passed, emit event
             var newPageId = _entityIndex.NextId(ResourceType.ExhibitPage);
 
+
             var ev = new ExhibitPageCreated3
             {
                 Id = newPageId,
@@ -215,7 +214,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
-
+            
             if (!_entityIndex.Exists(ResourceType.ExhibitPage, id))
                 return NotFound();
 
@@ -268,8 +267,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 UserId = User.Identity.GetUserIdentity(),
                 Timestamp = DateTimeOffset.Now
             };
-
             await _eventStore.AppendEventAsync(ev);
+
             return NoContent();
         }
 
@@ -346,11 +345,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (args.Image != null && !_mediaIndex.IsImage(args.Image.Value))
                 ModelState.AddModelError(nameof(args.Image),
                     ErrorMessages.ImageNotFound(args.Image.Value));
-
-            // ensure referenced audio exists
-            if (args.Audio != null && !_mediaIndex.IsAudio(args.Audio.Value))
-                ModelState.AddModelError(nameof(args.Audio),
-                    ErrorMessages.AudioNotFound(args.Audio.Value));
 
             // ensure referenced slider page images exist
             if (args.Images != null)

--- a/HiP-DataStore/Controllers/RoutesController.cs
+++ b/HiP-DataStore/Controllers/RoutesController.cs
@@ -7,7 +7,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -138,7 +137,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 Properties = args,
                 Timestamp = DateTimeOffset.Now
             };
-
+            
             await _eventStore.AppendEventAsync(ev);
             return Created($"{Request.Scheme}://{Request.Host}/api/Routes/{ev.Id}", ev.Id);
         }
@@ -201,7 +200,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 UserId = User.Identity.GetUserIdentity(),
                 Timestamp = DateTimeOffset.Now
             };
-
             await _eventStore.AppendEventAsync(ev);
             return NoContent();
         }

--- a/HiP-DataStore/Controllers/ScoreBoardController.cs
+++ b/HiP-DataStore/Controllers/ScoreBoardController.cs
@@ -1,18 +1,18 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using MongoDB.Driver;
-using PaderbornUniversity.SILab.Hip.DataStore.Core;
-using PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel;
-using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
-using PaderbornUniversity.SILab.Hip.DataStore.Model;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.DataStore.Utility;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
+﻿using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
+using MongoDB.Driver;
 using System.Linq;
 using System.Threading.Tasks;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.DataStore.Core;
+using PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
+using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
+using Microsoft.AspNetCore.Authorization;
+using PaderbornUniversity.SILab.Hip.DataStore.Utility;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 {
@@ -24,11 +24,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         private readonly CacheDatabaseManager _db;
         private readonly ScoreBoardIndex _board;
 
-        public ScoreBoardController(EventStoreClient ev, CacheDatabaseManager db, InMemoryCache cache)
+        public ScoreBoardController(EventStoreClient ev, CacheDatabaseManager db, IEnumerable<IDomainIndex> indices)
         {
             _eventStore = ev;
             _db = db;
-            _board = cache.Index<ScoreBoardIndex>();
+            _board = indices.OfType<ScoreBoardIndex>().First();
         }
 
         [HttpGet]

--- a/HiP-DataStore/Controllers/TagsController.cs
+++ b/HiP-DataStore/Controllers/TagsController.cs
@@ -6,7 +6,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,14 +27,14 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         private readonly TagIndex _tagIndex;
         private readonly ReferencesIndex _referencesIndex;
 
-        public TagsController(EventStoreClient eventStore, CacheDatabaseManager db, InMemoryCache cache)
+        public TagsController(EventStoreClient eventStore, CacheDatabaseManager db, IEnumerable<IDomainIndex> indices)
         {
             _eventStore = eventStore;
             _db = db;
-            _entityIndex = cache.Index<EntityIndex>();
-            _mediaIndex = cache.Index<MediaIndex>();
-            _tagIndex = cache.Index<TagIndex>();
-            _referencesIndex = cache.Index<ReferencesIndex>();
+            _entityIndex = indices.OfType<EntityIndex>().First();
+            _mediaIndex = indices.OfType<MediaIndex>().First();
+            _tagIndex = indices.OfType<TagIndex>().First();
+            _referencesIndex = indices.OfType<ReferencesIndex>().First();
         }
 
         [HttpGet("ids")]
@@ -158,7 +157,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         [ProducesResponseType(403)]
         [ProducesResponseType(404)]
         [ProducesResponseType(409)]
-        public async Task<IActionResult> UpdateByIdAsync(int id, [FromBody]TagArgs args)
+        public async Task<IActionResult> UpdateById(int id, [FromBody]TagArgs args)
         {
             ValidateTagArgs(args);
 
@@ -193,7 +192,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> DeleteByIdAsync(int id)
+        public async Task<IActionResult> DeleteById(int id)
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
@@ -214,7 +213,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 UserId = User.Identity.GetUserIdentity(),
                 Timestamp = DateTimeOffset.Now
             };
-
             await _eventStore.AppendEventAsync(ev);
             return NoContent();
         }

--- a/HiP-DataStore/Core/DocRefExtensions.cs
+++ b/HiP-DataStore/Core/DocRefExtensions.cs
@@ -1,0 +1,83 @@
+﻿using MongoDB.Driver;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    public static class DocRefExtensions
+    {
+        /// <summary>
+        /// Resolves a reference to a document.
+        /// Both, database name and collection name of the referenced document, must be specified.
+        /// </summary>
+        public static T Load<T>(this DocRef<T> docRef, IMongoClient client)
+        {
+            if (string.IsNullOrEmpty(docRef.Database))
+                throw new InvalidOperationException($"The DocRef does not specify the database of the referenced document. Try Load(IMongoDatabase)");
+
+            return docRef.Load(client.GetDatabase(docRef.Database));
+        }
+
+        /// <summary>
+        /// Resolves a reference to a document.
+        /// Collection name of the referenced document must be specified, database name is ignored.
+        /// </summary>
+        public static T Load<T>(this DocRef<T> docRef, IMongoDatabase database)
+        {
+            if (string.IsNullOrEmpty(docRef.Collection))
+                throw new InvalidOperationException($"The DocRef does not specify the collection of the referenced document. Try Load(IMongoCollection).");
+
+            return docRef.Load(database.GetCollection<T>(docRef.Collection));
+        }
+
+        /// <summary>
+        /// Resolves a reference to a document. Collection name and database name are ignored.
+        /// </summary>
+        public static T Load<T>(this DocRef<T> docRef, IMongoCollection<T> collection)
+        {
+            return collection
+                .Find(Builders<T>.Filter.Eq("_id", docRef.Id))
+                .SingleOrDefault();
+        }
+
+        /// <summary>
+        /// Resolves a collection of document references.
+        /// Both, database name and collection name of the referenced document, must be specified.
+        /// </summary>
+        public static IReadOnlyCollection<T> LoadAll<T>(this DocRefList<T> docRef, IMongoClient client)
+        {
+            if (string.IsNullOrEmpty(docRef.Database))
+                throw new InvalidOperationException($"The DocRef does not specify the database of the referenced document. Try Load(IMongoDatabase)");
+
+            return docRef.LoadAll(client.GetDatabase(docRef.Database));
+        }
+
+        /// <summary>
+        /// Resolves a collection of document references.
+        /// Collection name of the referenced documents must be specified, database name is ignored.
+        /// </summary>
+        public static IReadOnlyCollection<T> LoadAll<T>(this DocRefList<T> docRef, IMongoDatabase database)
+        {
+            if (string.IsNullOrEmpty(docRef.Collection))
+                throw new InvalidOperationException($"The DocRef does not specify the collection of the referenced document. Try Load(IMongoCollection).");
+
+            return docRef.LoadAll(database.GetCollection<T>(docRef.Collection));
+        }
+
+        /// <summary>
+        /// Resolves a collection of document references. Collection name and database name are ignored.
+        /// </summary>
+        public static IReadOnlyCollection<T> LoadAll<T>(this DocRefList<T> docRef, IMongoCollection<T> collection)
+        {
+            // Less efficient approach, preserves ordering
+            return docRef.Ids
+                .Select(id => collection.Find(Builders<T>.Filter.Eq("_id", id)).First())
+                .ToList();
+
+            // Simple, efficient approach (unfortunately doesn't preserve ordering):
+            // return collection.Find(Builders<T>.Filter.In("_id", docRef.Ids)).ToList();
+        }
+    }
+}

--- a/HiP-DataStore/Core/EventDataExtensions.cs
+++ b/HiP-DataStore/Core/EventDataExtensions.cs
@@ -1,0 +1,61 @@
+﻿using EventStore.ClientAPI;
+using Newtonsoft.Json;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    public static class EventDataExtensions
+    {
+        private const string EventClrTypeHeader = "ClrType";
+        private static readonly Dictionary<string, object> NoHeaders = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Converts an <see cref="IEvent"/> object to EventStore's <see cref="EventData"/>.
+        /// </summary>
+        public static EventData ToEventData(this IEvent ev, Guid eventId, IDictionary<string, object> headers = null)
+        {
+            var type = ev.GetType();
+
+            var eventHeaders = new Dictionary<string, object>(headers ?? NoHeaders)
+            {
+                { EventClrTypeHeader, type.AssemblyQualifiedName }
+            };
+            
+            var data = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(ev));
+            var metadata = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(eventHeaders));
+
+            return new EventData(eventId, type.Name, true, data, metadata);
+        }
+
+        /// <summary>
+        /// Converts EventStore's <see cref="RecordedEvent"/> to an <see cref="IEvent"/> object.
+        /// </summary>
+        public static IEvent ToIEvent(this RecordedEvent ev)
+        {
+            if (!ev.IsJson)
+                throw new ArgumentException("The event is not JSON-formatted");
+
+            var metadata = Encoding.UTF8.GetString(ev.Metadata);
+            var headers = JsonConvert.DeserializeObject<IDictionary<string, object>>(metadata);
+
+            if (headers == null || !headers.TryGetValue(EventClrTypeHeader, out var typeNameEntry))
+                throw new ArgumentException("Cannot resolve event type: Metadata does not specify the CLR type");
+
+            var typeName = typeNameEntry.ToString();
+            var type = Type.GetType(typeName);
+
+            if (type == null)
+                throw new ArgumentException($"Cannot resolve event type: '{typeName}'");
+
+            if (!typeof(IEvent).IsAssignableFrom(type))
+                throw new ArgumentException($"The event type does not implement {nameof(IEvent)}");
+
+            var json = Encoding.UTF8.GetString(ev.Data);
+            return (IEvent)JsonConvert.DeserializeObject(json, type);
+        }
+    }
+}

--- a/HiP-DataStore/Core/EventStoreClient.cs
+++ b/HiP-DataStore/Core/EventStoreClient.cs
@@ -1,15 +1,15 @@
 ﻿using EventStore.ClientAPI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
+using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Utility;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using ESL = PaderbornUniversity.SILab.Hip.EventSourcing.EventStoreLlp;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core
 {
@@ -22,15 +22,14 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
     /// </remarks>
     public class EventStoreClient
     {
+        private readonly IReadOnlyCollection<IDomainIndex> _indices;
         private readonly ILogger<EventStoreClient> _logger;
         private readonly string _streamName;
-        private readonly IEventStore _store;
-        private readonly InMemoryCache _cache;
 
-        public IEventStream EventStream => _store.Streams[_streamName];
+        public IEventStoreConnection Connection { get; }
 
         public EventStoreClient(
-            InMemoryCache cache,
+            IEnumerable<IDomainIndex> indices,
             IOptions<EndpointConfig> config,
             ILogger<EventStoreClient> logger)
         {
@@ -50,20 +49,18 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
 
             // Establish connection to Event Store
             var uri = new Uri(config.Value.EventStoreHost);
-            var connection = EventStoreConnection.Create(settings, uri);
-            connection.ConnectAsync().Wait();
-            
-            _store = new ESL.EventStore(connection);
+            Connection = EventStoreConnection.Create(settings, uri);
+            Connection.ConnectAsync().Wait();
 
             logger.LogInformation($"Connected to Event Store on '{uri.Host}', using stream '{_streamName}'");
 
             // Update stream to the latest version
-            var migrationResult = StreamMigrator.MigrateAsync(_store, _streamName).Result;
+            var migrationResult = StreamMigrator.MigrateAsync(Connection, _streamName).Result;
             if (migrationResult.fromVersion != migrationResult.toVersion)
                 logger.LogInformation($"Migrated stream '{_streamName}' from version '{migrationResult.fromVersion}' to version '{migrationResult.toVersion}'");
 
             // Setup IDomainIndex-indices
-            _cache = cache;
+            _indices = indices.ToList();
             PopulateIndicesAsync().Wait();
         }
 
@@ -71,40 +68,44 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
         /// Starts a new transaction. Append events to the transaction and eventually commit
         /// the transaction to persist the events to the event stream.
         /// </summary>
-        public EventStreamTransaction BeginTransaction()
+        public EventStoreClientTransaction BeginTransaction()
         {
-            return _store.Streams[_streamName].BeginTransaction();
+            return new EventStoreClientTransaction(this);
         }
 
         /// <summary>
         /// Appends a single event to the event stream. If you need to append multiple events in one batch,
         /// either use <see cref="AppendEventsAsync(IEnumerable{IEvent})"/> or <see cref="BeginTransaction"/>
-        /// and <see cref="EventStreamTransaction.Commit"/> instead.
+        /// and <see cref="EventStoreClientTransaction.CommitAsync"/> instead.
         /// </summary>
         public async Task AppendEventAsync(IEvent ev)
         {
             await AppendEventsAsync(new[] { ev });
         }
 
-        public Task AppendEventsAsync(IEnumerable<IEvent> events) =>
+        public Task<WriteResult> AppendEventsAsync(IEnumerable<IEvent> events) =>
             AppendEventsAsync(events?.ToList());
 
-        public async Task AppendEventsAsync(IReadOnlyCollection<IEvent> events)
+        public async Task<WriteResult> AppendEventsAsync(IReadOnlyCollection<IEvent> events)
         {
             if (events == null)
                 throw new ArgumentNullException(nameof(events));
 
             // persist events in Event Store
-            await _store.Streams[_streamName].AppendManyAsync(events);
+            var eventData = events.Select(ev => ev.ToEventData(Guid.NewGuid()));
+            var result = await Connection.AppendToStreamAsync(_streamName, ExpectedVersion.Any, eventData);
 
             // forward events to indices so they can update their state
             foreach (var ev in events)
-                _cache.ApplyEvent(ev);
+                foreach (var index in _indices)
+                    index.ApplyEvent(ev);
+
+            return result;
         }
 
         private async Task PopulateIndicesAsync()
         {
-            var events = _store.Streams[_streamName].GetEnumerator();
+            var events = new EventStoreStreamEnumerator(Connection, _streamName);
             var totalCount = 0;
 
             events.EventParsingFailed += (_, exception) =>
@@ -113,7 +114,18 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
             while (await events.MoveNextAsync())
             {
                 totalCount++;
-                _cache.ApplyEvent(events.Current);
+
+                foreach (var index in _indices)
+                {
+                    try
+                    {
+                        index.ApplyEvent(events.Current);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogWarning($"Failed to populate index of type '{index.GetType().Name}' with event of type '{events.Current.GetType().Name}': {e}");
+                    }
+                }
             }
 
             _logger.LogInformation($"Populated indices with {totalCount} events");

--- a/HiP-DataStore/Core/EventStoreClientTransaction.cs
+++ b/HiP-DataStore/Core/EventStoreClientTransaction.cs
@@ -1,0 +1,58 @@
+﻿using EventStore.ClientAPI;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    /// <summary>
+    /// A transaction which aggregates multiple events in order to emit them in a single batch.
+    /// </summary>
+    public class EventStoreClientTransaction : IDisposable
+    {
+        private readonly EventStoreClient _client;
+        private readonly List<IEvent> _events = new List<IEvent>();
+        private bool _isCommitted;
+        private bool _isDisposed;
+
+        public EventStoreClientTransaction(EventStoreClient client)
+        {
+            _client = client;
+        }
+
+        public void Append(IEvent ev)
+        {
+            VerifyState();
+            _events.Add(ev);
+        }
+
+        public void Append(IEnumerable<IEvent> events)
+        {
+            VerifyState();
+            _events.AddRange(events);
+        }
+
+        /// <summary>
+        /// Persists all events added to this transaction in the Event Store stream.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<WriteResult> CommitAsync()
+        {
+            VerifyState();
+            _isCommitted = true;
+            return await _client.AppendEventsAsync(_events);
+        }
+
+        private void VerifyState()
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(nameof(EventStoreClientTransaction));
+
+            if (_isCommitted)
+                throw new InvalidOperationException("A commit has already been executed");
+        }
+
+        public void Dispose() => _isDisposed = true;
+    }
+}

--- a/HiP-DataStore/Core/EventStoreStreamEnumerator.cs
+++ b/HiP-DataStore/Core/EventStoreStreamEnumerator.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using EventStore.ClientAPI;
+using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    /// <summary>
+    /// Provides an easy-to-consume async enumerator to iterate over all events in an Event Store stream.
+    /// </summary>
+    public class EventStoreStreamEnumerator : IAsyncEnumerator<IEvent>
+    {
+        private const int PageSize = 4096; // only 4096 events can be retrieved in one call
+
+        private readonly IEventStoreConnection _connection;
+        private readonly string _streamName;
+        private readonly Queue<IEvent> _buffer = new Queue<IEvent>();
+
+        private long _startPosition = StreamPosition.Start;
+        private bool _isEndOfStream;
+
+        public IEvent Current => _buffer.Peek();
+
+        public event EventHandler<EventParsingException> EventParsingFailed;
+
+        public EventStoreStreamEnumerator(IEventStoreConnection connection, string streamName)
+        {
+            _connection = connection;
+            _streamName = streamName;
+        }
+
+        public async Task<bool> MoveNextAsync()
+        {
+            if (_buffer.Count > 0)
+            {
+                _buffer.Dequeue();
+
+                if (_buffer.Count > 0)
+                    return true;
+            }
+
+            if (_isEndOfStream)
+                return false;
+
+            // Why the 'while'? If the stream was soft-deleted in the past it starts at an event with number != 0.
+            // So the first read operation returns 0 events, but reports the actual start position of the stream
+            // (currentSlice.NextEventNumber). Then, a second read is required to actually read the first few events.
+            while (_buffer.Count == 0 && !_isEndOfStream)
+            {
+                var currentSlice = await _connection.ReadStreamEventsForwardAsync(_streamName, _startPosition, PageSize, false);
+
+                foreach (var eventData in currentSlice.Events)
+                {
+                    try
+                    {
+                        var ev = eventData.Event.ToIEvent().MigrateToLatestVersion();
+                        _buffer.Enqueue(ev);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        EventParsingFailed?.Invoke(this, new EventParsingException(eventData, e));
+                    }
+                }
+
+                _startPosition = currentSlice.NextEventNumber;
+                _isEndOfStream = currentSlice.IsEndOfStream;
+            }
+
+            return _buffer.Count > 0;
+        }
+
+        public void Reset()
+        {
+            _startPosition = 0;
+            _isEndOfStream = false;
+            _buffer.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The exception that is thrown when raw event data cannot be deserialized into a corresponding CLR object.
+    /// </summary>
+    public class EventParsingException : Exception
+    {
+        public ResolvedEvent RawEvent { get; }
+
+        public EventParsingException(ResolvedEvent rawEvent, Exception innerException)
+            : base($"The event data of type '{rawEvent.Event.EventType}' could not be deserialized into " +
+                   $"an instance of '{nameof(IEvent)}'", innerException)
+        {
+            RawEvent = rawEvent;
+        }
+    }
+}

--- a/HiP-DataStore/Core/IAsyncEnumerator.cs
+++ b/HiP-DataStore/Core/IAsyncEnumerator.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    /// <summary>
+    /// An asynchronous enumerator interface, similar to the built-in synchronous
+    /// <see cref="System.Collections.Generic.IEnumerator{T}"/> interface.
+    /// </summary>
+    public interface IAsyncEnumerator<out T>
+    {
+        /// <summary>
+        /// Gets the element in the collection at the current position of the enumerator.
+        /// </summary>
+        T Current { get; }
+
+        /// <summary>
+        /// Advances the enumerator to the next element of the collection.
+        /// </summary>
+        /// <returns>True if successfully moved.</returns>
+        Task<bool> MoveNextAsync();
+
+        /// <summary>
+        /// Sets the enumerator to its initial position, which is before the first element in the collection.
+        /// </summary>
+        void Reset();
+    }
+}

--- a/HiP-DataStore/Core/Migrations/IStreamMigration.cs
+++ b/HiP-DataStore/Core/Migrations/IStreamMigration.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    /// <summary>
+    /// The interface for Event Store stream migrations.
+    /// </summary>
+    /// <remarks>
+    /// Migrations are applied using the <see cref="StreamMigrator"/> class. In order for <see cref="StreamMigrator"/>
+    /// to recognize a migration class, the class must implement <see cref="IStreamMigration"/> and must be annotated
+    /// with the <see cref="StreamMigrationAttribute"/>.
+    /// </remarks>
+    public interface IStreamMigration
+    {
+        Task MigrateAsync(IStreamMigrationArgs e);
+    }
+}

--- a/HiP-DataStore/Core/Migrations/IStreamMigrationArgs.cs
+++ b/HiP-DataStore/Core/Migrations/IStreamMigrationArgs.cs
@@ -1,0 +1,10 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    public interface IStreamMigrationArgs
+    {
+        IAsyncEnumerator<IEvent> GetExistingEvents();
+        void AppendEvent(IEvent ev);
+    }
+}

--- a/HiP-DataStore/Core/Migrations/StreamMigrationArgs.cs
+++ b/HiP-DataStore/Core/Migrations/StreamMigrationArgs.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using EventStore.ClientAPI;
+using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    public class StreamMigrationArgs : IStreamMigrationArgs
+    {
+        private readonly IEventStoreConnection _connection;
+        private readonly string _streamName;
+        private readonly List<EventData> _eventsToAppend = new List<EventData>();
+
+        public IReadOnlyList<EventData> EventsToAppend => _eventsToAppend;
+
+        public StreamMigrationArgs(IEventStoreConnection connection, string streamName)
+        {
+            _connection = connection;
+            _streamName = streamName;
+        }
+
+        public void AppendEvent(IEvent ev) => _eventsToAppend.Add(ev.ToEventData(Guid.NewGuid()));
+
+        public IAsyncEnumerator<IEvent> GetExistingEvents() =>
+            new EventStoreStreamEnumerator(_connection, _streamName);
+    }
+}

--- a/HiP-DataStore/Core/Migrations/StreamMigrationAttribute.cs
+++ b/HiP-DataStore/Core/Migrations/StreamMigrationAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    /// <summary>
+    /// Specifies the version for which a migration is applicable and the version the migration transforms the stream to.
+    /// </summary>
+    /// <remarks>
+    /// Migrations are applied using the <see cref="StreamMigrator"/> class. In order for <see cref="StreamMigrator"/>
+    /// to recognize a migration class, the class must implement <see cref="IStreamMigration"/> and must be annotated
+    /// with the <see cref="StreamMigrationAttribute"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class StreamMigrationAttribute : Attribute
+    {
+        /// <summary>
+        /// The stream version this migration is able to process.
+        /// </summary>
+        public int FromVersion { get; }
+
+        /// <summary>
+        /// The version the stream is migrated to.
+        /// </summary>
+        public int ToVersion { get; }
+
+        public StreamMigrationAttribute(int from, int to)
+        {
+            FromVersion = from;
+            ToVersion = to;
+        }
+    }
+}

--- a/HiP-DataStore/Core/Migrations/StreamMigrator.cs
+++ b/HiP-DataStore/Core/Migrations/StreamMigrator.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using System;
+using System.Reflection;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations
+{
+    /// <summary>
+    /// Provides methods to update an Event Store stream to the latest version by applying one or multiple
+    /// migrations defined in the HiP-DataStore assembly.
+    /// </summary>
+    public static class StreamMigrator
+    {
+        public const string StreamVersionMetadataKey = "StreamVersion";
+
+        public static async Task<(int fromVersion, int toVersion)> MigrateAsync(IEventStoreConnection connection, string streamName)
+        {
+            // Get current stream version from metadata
+            var initialVersion = await GetStreamVersionAsync(connection, streamName) ?? 0;
+            var currentVersion = initialVersion;
+            
+            // Find all applicable migrations in the current assembly
+            var availableMigrations = GetAvailableMigrations()
+                .Where(t => t.Properties.FromVersion >= currentVersion)
+                .OrderBy(t => t.Properties.FromVersion)
+                .ToList();
+
+            // Check for ambiguities (i.e. are there multiple migrations for the same source version?)
+            if (availableMigrations.GroupBy(t => t.Properties.FromVersion).Any(g => g.Count() > 1))
+                throw new InvalidOperationException("The assembly defines multiple migrations for the same source version");
+
+            // Repeatedly apply the migration with FromVersion == currentVersion and maximum ToVersion,
+            // until no more migrations are applicable
+            MigrationTypeInfo chosenMigration;
+
+            while ((chosenMigration = availableMigrations.FirstOrDefault(t => t.Properties.FromVersion == currentVersion)) != null)
+            {
+                // from the group of matching migrations, choose the one with maximum ToVersion
+                await ExecuteMigrationAsync(chosenMigration, connection, streamName);
+                currentVersion = chosenMigration.Properties.ToVersion;
+            }
+
+            return (initialVersion, currentVersion);
+        }
+
+        private static async Task<int?> GetStreamVersionAsync(IEventStoreConnection connection, string streamName)
+        {
+            var metadata = await connection.GetStreamMetadataAsync(streamName);
+            return metadata.StreamMetadata.TryGetValue(StreamVersionMetadataKey, out int version)
+                ? version
+                : default(int?);
+        }
+
+        private static IEnumerable<MigrationTypeInfo> GetAvailableMigrations()
+        {
+            return typeof(StreamMigrator).GetTypeInfo().Assembly.DefinedTypes
+                .Where(t => t.GetInterface(nameof(IStreamMigration)) != null)
+                .Select(t => new MigrationTypeInfo
+                {
+                    Type = t,
+                    Properties = t.GetCustomAttribute<StreamMigrationAttribute>()
+                })
+                .Where(t =>
+                    t.Properties != null && // type must have the [StreamMigration]-attribute
+                    t.Properties.ToVersion > t.Properties.FromVersion);
+        }
+
+        private static async Task ExecuteMigrationAsync(MigrationTypeInfo migrationType, IEventStoreConnection connection, string streamName)
+        {
+            var migration = (IStreamMigration)Activator.CreateInstance(migrationType.Type.AsType());
+            var args = new StreamMigrationArgs(connection, streamName);
+            await migration.MigrateAsync(args);
+
+            using (var transaction = await connection.StartTransactionAsync(streamName, ExpectedVersion.Any))
+            {
+                // Soft-delete the stream and recreate it by appending all new events
+                await connection.DeleteStreamAsync(streamName, ExpectedVersion.Any, hardDelete: false);
+                await connection.AppendToStreamAsync(streamName, ExpectedVersion.Any, args.EventsToAppend);
+
+                // Write new version to the stream's metadata
+                var metadata = await connection.GetStreamMetadataAsync(streamName);
+                var updatedMetadata = metadata.StreamMetadata.Copy()
+                    .SetCustomProperty(StreamVersionMetadataKey, migrationType.Properties.ToVersion);
+                await connection.SetStreamMetadataAsync(streamName, ExpectedVersion.Any, updatedMetadata);
+
+                await transaction.CommitAsync();
+            }
+        }
+
+        class MigrationTypeInfo
+        {
+            public TypeInfo Type { get; set; }
+            public StreamMigrationAttribute Properties { get; set; }
+        }
+    }
+}

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using EventStore.ClientAPI;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -6,8 +7,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Utility;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Mongo;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -23,6 +22,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
     {
         private readonly EventStoreClient _eventStore;
         private readonly IMongoDatabase _db;
+        private readonly ILogger<CacheDatabaseManager> _logger;
 
         public IMongoDatabase Database => _db;
 
@@ -35,6 +35,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
             // This also implies that, for now, the cache database always contains the entire data (not a subset).
             // In order to receive all the events, a Catch-Up Subscription is created.
 
+            _logger = logger;
+
             // 1) Open MongoDB connection and clear existing database
             var mongo = new MongoClient(config.Value.MongoDbHost);
             mongo.DropDatabase(config.Value.MongoDbName);
@@ -45,10 +47,30 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
             // 2) Subscribe to EventStore to receive all past and future events
             _eventStore = eventStore;
 
-            var subscription = _eventStore.EventStream.SubscribeCatchUp();
-            subscription.EventAppeared.Subscribe(ApplyEvent);
+            _eventStore.Connection.SubscribeToStreamFrom(
+                config.Value.EventStoreStream,
+                null, // don't use StreamPosition.Start (see https://groups.google.com/forum/#!topic/event-store/8tpXJMNEMqI),
+                CatchUpSubscriptionSettings.Default,
+                OnEventAppeared);
         }
-        
+
+        private void OnEventAppeared(EventStoreCatchUpSubscription subscription, ResolvedEvent resolvedEvent)
+        {
+            try
+            {
+                // Note regarding migration:
+                // Event types may change over time (properties get added/removed etc.)
+                // Whenever an event has multiple versions, an event of an obsolete type should be transformed to an event
+                // of the latest version, so that ApplyEvent(...) only has to deal with events of the current version.
+                var ev = resolvedEvent.Event.ToIEvent().MigrateToLatestVersion();
+                ApplyEvent(ev);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning($"{nameof(CacheDatabaseManager)} could not process an event: {e}");
+            }
+        }
+
         private void ApplyEvent(IEvent ev)
         {
             if (ev is ICrudEvent crudEvent)

--- a/HiP-DataStore/Core/WriteModel/EntityIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/EntityIndex.cs
@@ -4,7 +4,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Controllers;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using System.Linq;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 using PaderbornUniversity.SILab.Hip.DataStore.Utility;
 using System.Security.Principal;
 

--- a/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ExhibitPageIndex.cs
@@ -1,6 +1,5 @@
 ﻿using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 using System.Collections.Generic;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel

--- a/HiP-DataStore/Core/WriteModel/IDomainIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/IDomainIndex.cs
@@ -1,0 +1,12 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
+{
+    /// <summary>
+    /// An "index" caches specific parts of the domain model for efficient access during validation.
+    /// </summary>
+    public interface IDomainIndex
+    {
+        void ApplyEvent(IEvent e);
+    }
+}

--- a/HiP-DataStore/Core/WriteModel/MediaIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/MediaIndex.cs
@@ -2,7 +2,6 @@
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
 {

--- a/HiP-DataStore/Core/WriteModel/RatingIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/RatingIndex.cs
@@ -1,7 +1,7 @@
 ﻿using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
+
 using System.Collections.Generic;
 using System;
 

--- a/HiP-DataStore/Core/WriteModel/ReferencesIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ReferencesIndex.cs
@@ -1,9 +1,8 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-using System;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using System.Collections.Generic;
 using System.Linq;
+using System;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using System.Reflection;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel

--- a/HiP-DataStore/Core/WriteModel/ScoreBoardIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/ScoreBoardIndex.cs
@@ -1,9 +1,8 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
 {

--- a/HiP-DataStore/Core/WriteModel/TagIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/TagIndex.cs
@@ -1,5 +1,4 @@
 ﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/HiP-DataStore/HiP-DataStore.csproj
+++ b/HiP-DataStore/HiP-DataStore.csproj
@@ -1,30 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.DataStore</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreConfigFile>Nuget.Config</RestoreConfigFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="Core\DocRefExtensions.cs" />
-  </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="Media\Image\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.0.2-rc" />
+    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.0.0-alpha-1" />
     <PackageReference Include="HiP-WebserviceLib" Version="2.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.4.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/HiP-DataStore/Migrations/AboutMigration.md
+++ b/HiP-DataStore/Migrations/AboutMigration.md
@@ -1,0 +1,23 @@
+# About Migration and Versioning
+HiP-DataStore uses two kinds of "migrations" to make changes to the data model without loosing existing data.
+
+## Event Migration
+A light way of migration that is useful if small modifications to event types need to be made. For example, adding a property to an `ExhibitCreated`-event or changing the type of a property are good candidates for event migrations. Event migrations are applied "on the fly", i.e. whenever an event of an outdated type is read from the Event Store, it is transformed into an event of the new type.
+
+How to implement an event migration:
+1. Create a copy of the event type you want to modify, e.g. `FooCreated`, and append a version number to the type's name, e.g. `FooCreated2` (future versions of the event type should be called `FooCreated3`, `FooCreated4` and so on).
+1. Make changes to `FooCreated2`, e.g. add/remove properties, change property types etc. If `FooCreated` contained a property of a custom type, such as `FooArgs`, and you need to make changes to `FooArgs`, then you also need to create a copy of that and name it `FooArgs2`.
+1. Make `FooCreated` implement `IMigratable<FooCreated2>` so that events of the old type can be converted into events of the new type
+1. Adapt `CacheDatabaseManager` to handle the new event type
+1. Where necessary, adapt `IDomainIndex`-classes to handle the new event type
+1. Mark the old event type (`FooCreated`) as `[Obsolete]` so that you are warned if your code still uses it
+
+The main type to support event migration is `PaderbornUniversity.SILab.Hip.DataStore.Model.Events.IMigratable<T>`.
+
+## Stream Migration
+If the desired model change cannot be achieved with event migration, stream migration must be used. A stream migration basically recreates the whole event stream from scratch by reading through all the existing events and emitting new events based on the old ones. For example, if you have a type of event which you want to split into two events, a stream migration is a good way to do that. In contrast to event migrations, a stream migration is only applied once on application startup.
+
+A positive side-effect of stream migrations is that they persist all the event migrations. So after a stream migration has been applied, all obsolete event types up to this point in time can be removed, since the stream no longer contains events of obsolete types (but remember to keep the event types' names such as `FooCreated2` when deleting `FooCreated`).
+
+The types supporting stream migrations are located in `PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations`.
+The actual migrations should be stored in `PaderbornUniversity.SILab.Hip.DataStore.Migrations`.

--- a/HiP-DataStore/Migrations/Migration1PageOrderFeature.cs
+++ b/HiP-DataStore/Migrations/Migration1PageOrderFeature.cs
@@ -1,7 +1,7 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/HiP-DataStore/Migrations/Migration2FlatPageHierarchy.cs
+++ b/HiP-DataStore/Migrations/Migration2FlatPageHierarchy.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
+using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Rest;
 using System.Threading.Tasks;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
 
 #pragma warning disable CS0612 // We explicitly work with obsolete types here, so disable warnings for that
 namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations

--- a/HiP-DataStore/Migrations/Migration3CorrectExhibits.cs
+++ b/HiP-DataStore/Migrations/Migration3CorrectExhibits.cs
@@ -1,5 +1,5 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/HiP-DataStore/Migrations/Migration4RemoveReferenceEventsAndAddDeleteEventTimestamps.cs
+++ b/HiP-DataStore/Migrations/Migration4RemoveReferenceEventsAndAddDeleteEventTimestamps.cs
@@ -1,5 +1,5 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using System;
 using System.Threading.Tasks;
 

--- a/HiP-DataStore/Migrations/Migration5Authentication.cs
+++ b/HiP-DataStore/Migrations/Migration5Authentication.cs
@@ -1,5 +1,5 @@
-﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
-using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Core.Migrations;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using System.Threading.Tasks;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations


### PR DESCRIPTION
Reverts HiP-App/HiP-DataStore#57

Although the TFS and Docker Cloud builds completed successfully, on deployment Docker Cloud reports:

```
The build failed. Please fix the build errors and run again.
/mongodb-linux-x86_64-debian81-3.4.4/bin/mongod: error while loading shared libraries: libssl.so.1.0.0: cannot open shared object file: No such file or directory
/usr/share/dotnet/sdk/2.0.0/NuGet.targets(466,5): error : File '/dotnetapp/HiP-DataStore/Nuget.Config' does not exist.