### PR TITLE
Hotfix (update HiP-EventStoreLib to v0.13.0)

### DIFF
--- a/HiP-DataStore.Model/HiP-DataStore.Model.csproj
+++ b/HiP-DataStore.Model/HiP-DataStore.Model.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HiP-EventStoreLib" Version="0.10.0" />
+    <PackageReference Include="HiP-EventStoreLib" Version="0.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>

--- a/HiP-DataStore.Model/HiP-DataStore.Model.csproj
+++ b/HiP-DataStore.Model/HiP-DataStore.Model.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HiP-EventStoreLib" Version="0.11.0" />
+    <PackageReference Include="HiP-EventStoreLib" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>

--- a/HiP-DataStore/Core/EventStoreClient.cs
+++ b/HiP-DataStore/Core/EventStoreClient.cs
@@ -58,7 +58,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
             logger.LogInformation($"Connected to Event Store on '{uri.Host}', using stream '{_streamName}'");
 
             // Update stream to the latest version
-            var migrationResult = StreamMigrator.MigrateAsync(_store, _streamName).Result;
+            var thisAssembly = typeof(Startup).Assembly;
+            var migrationResult = StreamMigrator.MigrateAsync(_store, _streamName, thisAssembly).Result;
             if (migrationResult.fromVersion != migrationResult.toVersion)
                 logger.LogInformation($"Migrated stream '{_streamName}' from version '{migrationResult.fromVersion}' to version '{migrationResult.toVersion}'");
 


### PR DESCRIPTION
This updates HiP-EventStoreLib to v0.13.0, fixing a bug regarding migrations.