### PR TITLE
HIPCMS-781: History Part 1/2

### DIFF
--- a/HiP-DataStore.Model/HiP-DataStore.Model.csproj
+++ b/HiP-DataStore.Model/HiP-DataStore.Model.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HiP-EventStoreLib" Version="0.13.0" />
+    <PackageReference Include="HiP-EventStoreLib" Version="0.14.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -228,28 +228,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return ReferenceInfoHelper.GetReferenceInfo(ResourceType.Exhibit, id, _entityIndex, _referencesIndex);
         }
 
-        [HttpGet("{id}/History")]
-        public async Task<IActionResult> GetHistorySummary(int id)
-        {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            // TODO: Validate user permissions
-            var summary = await HistoryUtil.GetSummaryAsync(_eventStore.EventStream, (ResourceType.Exhibit, id));
-            return Ok(summary);
-        }
-
-        [HttpGet("{id}/History/{timestamp}")]
-        public async Task<IActionResult> GetHistoryVersion(int id, DateTimeOffset timestamp)
-        {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            // TODO: Validate user permissions
-            var version = await HistoryUtil.GetVersionAsync<Exhibit>(_eventStore.EventStream, (ResourceType.Exhibit, id), timestamp);
-            return Ok(version);
-        }
-
         [HttpGet("Rating/{id}")]
         [ProducesResponseType(typeof(RatingResult), 200)]
         [ProducesResponseType(400)]

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -228,6 +228,28 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return ReferenceInfoHelper.GetReferenceInfo(ResourceType.Exhibit, id, _entityIndex, _referencesIndex);
         }
 
+        [HttpGet("{id}/History")]
+        public async Task<IActionResult> GetHistorySummary(int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            // TODO: Validate user permissions
+            var summary = await HistoryUtil.GetSummaryAsync(_eventStore.EventStream, (ResourceType.Exhibit, id));
+            return Ok(summary);
+        }
+
+        [HttpGet("{id}/History/{timestamp}")]
+        public async Task<IActionResult> GetHistoryVersion(int id, DateTimeOffset timestamp)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            // TODO: Validate user permissions
+            var version = await HistoryUtil.GetVersionAsync<Exhibit>(_eventStore.EventStream, (ResourceType.Exhibit, id), timestamp);
+            return Ok(version);
+        }
+
         [HttpGet("Rating/{id}")]
         [ProducesResponseType(typeof(RatingResult), 200)]
         [ProducesResponseType(400)]

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -61,6 +61,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         // APIs to get the state of an entity at a specific point in time
 
+        /*
         [HttpGet("/api/Exhibits/{id}/History/{timestamp}")]
         public Task<IActionResult> GetExhibitVersion(int id, DateTimeOffset timestamp) =>
             GetVersionAsync<Exhibit>(ResourceType.Exhibit, id, timestamp);
@@ -80,6 +81,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         [HttpGet("/api/Tags/{id}/History/{timestamp}")]
         public Task<IActionResult> GetTagVersion(int id, DateTimeOffset timestamp) =>
             GetVersionAsync<Route>(ResourceType.Tag, id, timestamp);
+        */
 
 
         // Private helper methods

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -26,25 +26,19 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             _entityIndex = cache.Index<EntityIndex>();
         }
 
+        // APIs to get a summary of creation/deletion/updates
+
         [HttpGet("/api/Exhibits/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetExhibitSummary(int id) =>
             GetSummaryAsync(ResourceType.Exhibit, id);
-
-        [HttpGet("/api/Exhibits/{id}/History/{timestamp}")]
-        public Task<IActionResult> GetExhibitVersion(int id, DateTimeOffset timestamp) =>
-            GetVersionAsync<Exhibit>(ResourceType.Exhibit, id, timestamp);
-
+        
         [HttpGet("/api/Exhibits/Pages/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetExhibitPageSummary(int id) =>
             GetSummaryAsync(ResourceType.ExhibitPage, id);
-
-        [HttpGet("/api/Exhibits/Pages/{id}/History/{timestamp}")]
-        public Task<IActionResult> GetExhibitPageVersion(int id, DateTimeOffset timestamp) =>
-            GetVersionAsync<ExhibitPage>(ResourceType.ExhibitPage, id, timestamp);
 
         [HttpGet("/api/Media/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
@@ -52,19 +46,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         public Task<IActionResult> GetMediaSummary(int id) =>
             GetSummaryAsync(ResourceType.Media, id);
 
-        [HttpGet("/api/Media/{id}/History/{timestamp}")]
-        public Task<IActionResult> GetMediaVersion(int id, DateTimeOffset timestamp) =>
-            GetVersionAsync<MediaElement>(ResourceType.Media, id, timestamp);
-
         [HttpGet("/api/Routes/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetRouteSummary(int id) =>
-            GetSummaryAsync(ResourceType.Route, id);
-
-        [HttpGet("/api/Routes/{id}/History/{timestamp}")]
-        public Task<IActionResult> GetRouteVersion(int id, DateTimeOffset timestamp) =>
-            GetVersionAsync<Route>(ResourceType.Route, id, timestamp);
+           GetSummaryAsync(ResourceType.Route, id);
 
         [HttpGet("/api/Tags/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
@@ -72,10 +58,31 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
         public Task<IActionResult> GetTagSummary(int id) =>
             GetSummaryAsync(ResourceType.Tag, id);
 
+
+        // APIs to get the state of an entity at a specific point in time
+
+        [HttpGet("/api/Exhibits/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetExhibitVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<Exhibit>(ResourceType.Exhibit, id, timestamp);
+
+        [HttpGet("/api/Exhibits/Pages/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetExhibitPageVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<ExhibitPage>(ResourceType.ExhibitPage, id, timestamp);
+
+        [HttpGet("/api/Media/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetMediaVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<MediaElement>(ResourceType.Media, id, timestamp);
+
+        [HttpGet("/api/Routes/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetRouteVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<Route>(ResourceType.Route, id, timestamp);
+
         [HttpGet("/api/Tags/{id}/History/{timestamp}")]
         public Task<IActionResult> GetTagVersion(int id, DateTimeOffset timestamp) =>
             GetVersionAsync<Route>(ResourceType.Tag, id, timestamp);
 
+
+        // Private helper methods
 
         private async Task<IActionResult> GetSummaryAsync(ResourceType type, int id)
         {

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using PaderbornUniversity.SILab.Hip.DataStore.Core;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
@@ -12,28 +11,52 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
     /// <summary>
     /// Provides methods to obtain a version history or specific versions of an entity.
     /// </summary>
+    [Authorize]
     public class HistoryController : Controller
     {
         private readonly EventStoreClient _eventStore;
 
-        protected HistoryController(EventStoreClient eventStore)
-        {
-            _eventStore = eventStore;
-        }
+        public HistoryController(EventStoreClient eventStore) => _eventStore = eventStore;
 
         [HttpGet("/api/Exhibits/{id}/History")]
-        public Task<IActionResult> GetExhibitSummary(int id) => GetSummaryAsync(ResourceType.Exhibit, id);
+        public Task<IActionResult> GetExhibitSummary(int id) =>
+            GetSummaryAsync(ResourceType.Exhibit, id);
 
-        [HttpGet("/api/Exhibits/{id}/History")]
-        public Task<IActionResult> GetExhibitVersion(int id) => GetSummaryAsync(ResourceType.Exhibit, id);
+        [HttpGet("/api/Exhibits/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetExhibitVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<Exhibit>(ResourceType.Exhibit, id, timestamp);
 
         [HttpGet("/api/Exhibits/Pages/{id}/History")]
-        public Task<IActionResult> GetExhibitPageSummary(int id) => GetSummaryAsync(ResourceType.ExhibitPage, id);
+        public Task<IActionResult> GetExhibitPageSummary(int id) =>
+            GetSummaryAsync(ResourceType.ExhibitPage, id);
 
-        [HttpGet("/api/Exhibits/Pages/{id}/History")]
-        public Task<IActionResult> GetExhibitPageVersion(int id) => GetSummaryAsync(ResourceType.ExhibitPage, id);
+        [HttpGet("/api/Exhibits/Pages/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetExhibitPageVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<ExhibitPage>(ResourceType.ExhibitPage, id, timestamp);
 
-        // TODO: Implement for all resource types
+        [HttpGet("/api/Media/{id}/History")]
+        public Task<IActionResult> GetMediaSummary(int id) =>
+            GetSummaryAsync(ResourceType.Media, id);
+
+        [HttpGet("/api/Media/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetMediaVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<MediaElement>(ResourceType.Media, id, timestamp);
+
+        [HttpGet("/api/Routes/{id}/History")]
+        public Task<IActionResult> GetRouteSummary(int id) =>
+            GetSummaryAsync(ResourceType.Route, id);
+
+        [HttpGet("/api/Routes/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetRouteVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<Route>(ResourceType.Route, id, timestamp);
+
+        [HttpGet("/api/Tags/{id}/History")]
+        public Task<IActionResult> GetTagSummary(int id) =>
+            GetSummaryAsync(ResourceType.Tag, id);
+
+        [HttpGet("/api/Tags/{id}/History/{timestamp}")]
+        public Task<IActionResult> GetTagVersion(int id, DateTimeOffset timestamp) =>
+            GetVersionAsync<Route>(ResourceType.Tag, id, timestamp);
 
 
         private async Task<IActionResult> GetSummaryAsync(ResourceType type, int id)
@@ -46,7 +69,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return Ok(summary);
         }
 
-        [HttpGet("{id}/History/{timestamp}")]
         private async Task<IActionResult> GetVersionAsync<T>(ResourceType type, int id, DateTimeOffset timestamp)
             where T : ContentBase
         {

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using PaderbornUniversity.SILab.Hip.DataStore.Core;
+using PaderbornUniversity.SILab.Hip.DataStore.Model;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
+{
+    /// <summary>
+    /// Provides methods to obtain a version history or specific versions of an entity.
+    /// </summary>
+    public class HistoryController : Controller
+    {
+        private readonly EventStoreClient _eventStore;
+
+        protected HistoryController(EventStoreClient eventStore)
+        {
+            _eventStore = eventStore;
+        }
+
+        [HttpGet("/api/Exhibits/{id}/History")]
+        public Task<IActionResult> GetExhibitSummary(int id) => GetSummaryAsync(ResourceType.Exhibit, id);
+
+        [HttpGet("/api/Exhibits/{id}/History")]
+        public Task<IActionResult> GetExhibitVersion(int id) => GetSummaryAsync(ResourceType.Exhibit, id);
+
+        [HttpGet("/api/Exhibits/Pages/{id}/History")]
+        public Task<IActionResult> GetExhibitPageSummary(int id) => GetSummaryAsync(ResourceType.ExhibitPage, id);
+
+        [HttpGet("/api/Exhibits/Pages/{id}/History")]
+        public Task<IActionResult> GetExhibitPageVersion(int id) => GetSummaryAsync(ResourceType.ExhibitPage, id);
+
+        // TODO: Implement for all resource types
+
+
+        private async Task<IActionResult> GetSummaryAsync(ResourceType type, int id)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            // TODO: Validate user permissions
+            var summary = await HistoryUtil.GetSummaryAsync(_eventStore.EventStream, (type, id));
+            return Ok(summary);
+        }
+
+        [HttpGet("{id}/History/{timestamp}")]
+        private async Task<IActionResult> GetVersionAsync<T>(ResourceType type, int id, DateTimeOffset timestamp)
+            where T : ContentBase
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            // TODO: Validate user permissions
+            var version = await HistoryUtil.GetVersionAsync<T>(_eventStore.EventStream, (type, id), timestamp);
+            return Ok(version);
+        }
+    }
+}

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -30,30 +30,35 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
         [HttpGet("/api/Exhibits/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetExhibitSummary(int id) =>
             GetSummaryAsync(ResourceType.Exhibit, id);
         
         [HttpGet("/api/Exhibits/Pages/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetExhibitPageSummary(int id) =>
             GetSummaryAsync(ResourceType.ExhibitPage, id);
 
         [HttpGet("/api/Media/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetMediaSummary(int id) =>
             GetSummaryAsync(ResourceType.Media, id);
 
         [HttpGet("/api/Routes/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetRouteSummary(int id) =>
            GetSummaryAsync(ResourceType.Route, id);
 
         [HttpGet("/api/Tags/{id}/History")]
         [ProducesResponseType(typeof(HistorySummary), 200)]
+        [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         public Task<IActionResult> GetTagSummary(int id) =>
             GetSummaryAsync(ResourceType.Tag, id);

--- a/HiP-DataStore/Core/HistorySummary.cs
+++ b/HiP-DataStore/Core/HistorySummary.cs
@@ -33,7 +33,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
         /// <summary>
         /// A list of individual modifications (including creation and deletion).
         /// </summary>
-        public IList<Change> Changes { get; set; } = new List<Change>();
+        public IList<Change> Changes { get; } = new List<Change>();
 
         public class Change
         {

--- a/HiP-DataStore/Core/HistorySummary.cs
+++ b/HiP-DataStore/Core/HistorySummary.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    public class HistorySummary
+    {
+        /// <summary>
+        /// The time and date when the entity was created.
+        /// If the entity is effectively non-existent (i.e. has never been created or has been deleted),
+        /// no value is set.
+        /// </summary>
+        public DateTimeOffset? Created { get; set; }
+
+        /// <summary>
+        /// The time and date of the last creation, update or deletion.
+        /// If the entity is effectively non-existent (i.e. has never been created or has been deleted),
+        /// no value is set.
+        /// </summary>
+        public DateTimeOffset? LastModified { get; set; }
+
+        /// <summary>
+        /// The time and date when the entity was deleted.
+        /// A value is only set if the entity has been created and deleted before, but not (yet) recreated.
+        /// </summary>
+        public DateTimeOffset? Deleted { get; set; }
+
+        /// <summary>
+        /// The ID of the user who created the entity.
+        /// </summary>
+        public string Owner { get; set; }
+
+        /// <summary>
+        /// A list of individual modifications (including creation and deletion).
+        /// </summary>
+        public IList<Change> Changes { get; set; } = new List<Change>();
+
+        public class Change
+        {
+            public DateTimeOffset Timestamp { get; set; }
+            public string Description { get; set; }
+            public string UserId { get; set; }
+
+            public Change(DateTimeOffset timestamp, string description, string userId)
+            {
+                Timestamp = timestamp;
+                Description = description;
+                UserId = userId;
+            }
+        }
+    }
+}

--- a/HiP-DataStore/Core/HistoryUtil.cs
+++ b/HiP-DataStore/Core/HistoryUtil.cs
@@ -1,0 +1,134 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
+using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.EventSourcing;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Core
+{
+    public static class HistoryUtil
+    {
+        /// <summary>
+        /// Walks through the specified event stream to obtain a summary of when the specified entity
+        /// was created, modified and deleted. This is a potentially expensive operation.
+        /// </summary>
+        /// <remarks>
+        /// This method only looks for standard CRUD events (<see cref="ICreateEvent"/>, <see cref="IUpdateEvent"/>,   
+        /// <see cref="IDeleteEvent"/>). If for your specific entity type there are other event types the semantically
+        /// represent a change to the entity, these won't be part of the generated summary.
+        /// 
+        /// In case the entity lived different lives (i.e. has been recreated after deletion), only the most
+        /// recent "life" is considered for the history. Consider the following example event stream (with timestamps):
+        /// create (12:00), update (12:04), delete (13:20), create (13:55), delete (14:00), create (16:10), update (16:25).
+        /// In this case only the events from 16:10 and 16:25 will be considered and the property
+        /// <see cref="HistorySummary.Deleted"/> will not be set.
+        /// 
+        /// The event stream is assumed to be consistent. If the stream is inconsistent (e.g. has a create event
+        /// immediately followed by another create event), the behavior and resulting summary is undefined.
+        /// </remarks>
+        public static async Task<HistorySummary> GetSummaryAsync(IEventStream eventStream, EntityId entityId)
+        {
+            var enumerator = eventStream.GetEnumerator();
+            var summary = new HistorySummary();
+
+            while (await enumerator.MoveNextAsync())
+            {
+                if (enumerator.Current is ICrudEvent crudEvent &&
+                    crudEvent.GetEntityType() == entityId.Type && crudEvent.Id == entityId.Id)
+                {
+                    var timestamp = crudEvent.Timestamp;
+                    var user = (crudEvent as IUserActivityEvent).UserId;
+
+                    switch (crudEvent)
+                    {
+                        case ICreateEvent createEvent:
+                            if (summary.Created.HasValue)
+                            {
+                                // assumption: entity was deleted before and is now recreated (we don't check if there
+                                // was a delete event before; it's not our job to validate the stream's consistency)
+                                summary = new HistorySummary();
+                            }
+
+                            summary.Owner = user;
+                            summary.Created = timestamp;
+                            summary.LastModified = timestamp;
+                            summary.Changes.Add(new Change(timestamp, "Created", user));
+                            break;
+
+                        case IUpdateEvent updateEvent:
+                            summary.LastModified = timestamp;
+                            summary.Changes.Add(new Change(timestamp, "Updated", user));
+                            break;
+
+                        case IDeleteEvent deleteEvent:
+                            summary.LastModified = timestamp;
+                            summary.Deleted = timestamp;
+                            summary.Changes.Add(new Change(timestamp, "Deleted", user));
+                            break;
+                    }
+                }
+            }
+
+            return summary;
+        }
+
+        /// <summary>
+        /// Gets an entity as it was present at a specific point in time.
+        /// </summary>
+        public static Task<T> GetVersionAsync<T>(IEventStream eventStream, EntityId entityId, DateTimeOffset timestamp)
+            where T : ContentBase
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+    }
+
+    public class HistorySummary
+    {
+        /// <summary>
+        /// The time and date when the entity was created.
+        /// If the entity is effectively non-existent (i.e. has never been created or has been deleted),
+        /// no value is set.
+        /// </summary>
+        public DateTimeOffset? Created { get; set; }
+
+        /// <summary>
+        /// The time and date of the last creation, update or deletion.
+        /// If the entity is effectively non-existent (i.e. has never been created or has been deleted),
+        /// no value is set.
+        /// </summary>
+        public DateTimeOffset? LastModified { get; set; }
+
+        /// <summary>
+        /// The time and date when the entity was deleted.
+        /// A value is only set if the entity has been created and deleted before, but not (yet) recreated.
+        /// </summary>
+        public DateTimeOffset? Deleted { get; set; }
+
+        /// <summary>
+        /// The ID of the user who created the entity.
+        /// </summary>
+        public string Owner { get; set; }
+
+        /// <summary>
+        /// A list of individual modifications (including creation and deletion).
+        /// </summary>
+        public IList<Change> Changes { get; set; } = new List<Change>();
+    }
+
+    public class Change
+    {
+        public DateTimeOffset Timestamp { get; set; }
+        public string Description { get; set; }
+        public string UserId { get; set; }
+
+        public Change(DateTimeOffset timestamp, string description, string userId)
+        {
+            Timestamp = timestamp;
+            Description = description;
+            UserId = userId;
+        }
+    }
+}

--- a/HiP-DataStore/Core/HistoryUtil.cs
+++ b/HiP-DataStore/Core/HistoryUtil.cs
@@ -54,18 +54,18 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
                             summary.Owner = user;
                             summary.Created = timestamp;
                             summary.LastModified = timestamp;
-                            summary.Changes.Add(new Change(timestamp, "Created", user));
+                            summary.Changes.Add(new HistorySummary.Change(timestamp, "Created", user));
                             break;
 
                         case IUpdateEvent updateEvent:
                             summary.LastModified = timestamp;
-                            summary.Changes.Add(new Change(timestamp, "Updated", user));
+                            summary.Changes.Add(new HistorySummary.Change(timestamp, "Updated", user));
                             break;
 
                         case IDeleteEvent deleteEvent:
                             summary.LastModified = timestamp;
                             summary.Deleted = timestamp;
-                            summary.Changes.Add(new Change(timestamp, "Deleted", user));
+                            summary.Changes.Add(new HistorySummary.Change(timestamp, "Deleted", user));
                             break;
                     }
                 }
@@ -116,19 +116,19 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
         /// A list of individual modifications (including creation and deletion).
         /// </summary>
         public IList<Change> Changes { get; set; } = new List<Change>();
-    }
 
-    public class Change
-    {
-        public DateTimeOffset Timestamp { get; set; }
-        public string Description { get; set; }
-        public string UserId { get; set; }
-
-        public Change(DateTimeOffset timestamp, string description, string userId)
+        public class Change
         {
-            Timestamp = timestamp;
-            Description = description;
-            UserId = userId;
+            public DateTimeOffset Timestamp { get; set; }
+            public string Description { get; set; }
+            public string UserId { get; set; }
+
+            public Change(DateTimeOffset timestamp, string description, string userId)
+            {
+                Timestamp = timestamp;
+                Description = description;
+                UserId = userId;
+            }
         }
     }
 }

--- a/HiP-DataStore/Core/HistoryUtil.cs
+++ b/HiP-DataStore/Core/HistoryUtil.cs
@@ -3,7 +3,6 @@ using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
 using PaderbornUniversity.SILab.Hip.EventSourcing;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Core
@@ -82,53 +81,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
         {
             // TODO
             throw new NotImplementedException();
-        }
-    }
-
-    public class HistorySummary
-    {
-        /// <summary>
-        /// The time and date when the entity was created.
-        /// If the entity is effectively non-existent (i.e. has never been created or has been deleted),
-        /// no value is set.
-        /// </summary>
-        public DateTimeOffset? Created { get; set; }
-
-        /// <summary>
-        /// The time and date of the last creation, update or deletion.
-        /// If the entity is effectively non-existent (i.e. has never been created or has been deleted),
-        /// no value is set.
-        /// </summary>
-        public DateTimeOffset? LastModified { get; set; }
-
-        /// <summary>
-        /// The time and date when the entity was deleted.
-        /// A value is only set if the entity has been created and deleted before, but not (yet) recreated.
-        /// </summary>
-        public DateTimeOffset? Deleted { get; set; }
-
-        /// <summary>
-        /// The ID of the user who created the entity.
-        /// </summary>
-        public string Owner { get; set; }
-
-        /// <summary>
-        /// A list of individual modifications (including creation and deletion).
-        /// </summary>
-        public IList<Change> Changes { get; set; } = new List<Change>();
-
-        public class Change
-        {
-            public DateTimeOffset Timestamp { get; set; }
-            public string Description { get; set; }
-            public string UserId { get; set; }
-
-            public Change(DateTimeOffset timestamp, string description, string userId)
-            {
-                Timestamp = timestamp;
-                Description = description;
-                UserId = userId;
-            }
         }
     }
 }

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -45,8 +45,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
             // 2) Subscribe to EventStore to receive all past and future events
             _eventStore = eventStore;
 
-            var subscription = _eventStore.EventStream.SubscribeCatchUp();
-            subscription.EventAppeared.Subscribe(ApplyEvent);
+            var subscription = _eventStore.EventStream.SubscribeCatchUp(ApplyEvent);
         }
         
         private void ApplyEvent(IEvent ev)

--- a/HiP-DataStore/Utility/UserPermissions.cs
+++ b/HiP-DataStore/Utility/UserPermissions.cs
@@ -55,6 +55,12 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Utility
             return CheckRoles(identity);
         }
 
+        public static bool IsAllowedToGetHistory(IIdentity identity, string ownerId)
+        {
+            // The entity owner as well as supervisors and administrators are allowed
+            return (ownerId == identity.GetUserIdentity()) || CheckRoles(identity);
+        }
+
         //Check if the user has the nessesary roles
         static bool CheckRoles(IIdentity identity, UserRoles allowedToProceed = UserRoles.Administrator | UserRoles.Supervisor)
         {


### PR DESCRIPTION
There are two primary history features:
1. Provide APIs to get an overview of who changed which entity at which point in time
2. Provide APIs to get the state of an entity at any given point in time

This PR implements part 1. It contains some preparation code for part 2 as well, but part 2 is not implemented at this point and it is not really a requirement of HIPCMS-781.