### PR TITLE
HIPCMS-780: Make use of HiP-ThumbnailService

### DIFF
--- a/HiP-DataStore.Model/Rest/MediaResult.cs
+++ b/HiP-DataStore.Model/Rest/MediaResult.cs
@@ -8,14 +8,28 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
     public class MediaResult
     {
         public int Id { get; set; }
+
         public string Title { get; set; }
+
         public string Description { get; set; }
+
         public bool Used { get; set; }
+
+        /// <summary>
+        /// The URL from which the file can be downloaded.
+        /// For images, a URL pointing to the thumbnail service.
+        /// For audio, a URL pointing to "GET /api/Media/{id}/File".
+        /// </summary>
+        public string File { get; set; }
+
         public string UserId { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public MediaType Type { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public ContentStatus Status { get; set; }
+
         public DateTimeOffset Timestamp { get; set; }
 
         public MediaResult()

--- a/HiP-DataStore.Model/Rest/RatingArgs.cs
+++ b/HiP-DataStore.Model/Rest/RatingArgs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 {

--- a/HiP-DataStore/Controllers/ExhibitPagesController.cs
+++ b/HiP-DataStore/Controllers/ExhibitPagesController.cs
@@ -76,10 +76,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            args = args ?? new ExhibitPageQueryArgs();
+
             if (args.Status == ContentStatus.Deleted && !UserPermissions.IsAllowedToGetDeleted(User.Identity))
                 return Forbid();
-
-            args = args ?? new ExhibitPageQueryArgs();
 
             var query = _db.Database.GetCollection<ExhibitPage>(ResourceType.ExhibitPage.Name).AsQueryable();
             return QueryExhibitPages(query, args);
@@ -133,10 +133,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            args = args ?? new ExhibitPageQueryArgs();
+
             if (args.Status == ContentStatus.Deleted && !UserPermissions.IsAllowedToGetDeleted(User.Identity))
                 return Forbid();
-
-            args = args ?? new ExhibitPageQueryArgs();
 
             var exhibit = _db.Database.GetCollection<Exhibit>(ResourceType.Exhibit.Name)
                 .AsQueryable()

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -63,10 +63,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            args = args ?? new ExhibitQueryArgs();
+
             if (args.Status == ContentStatus.Deleted && !UserPermissions.IsAllowedToGetDeleted(User.Identity))
                 return Forbid();
-
-            args = args ?? new ExhibitQueryArgs();
 
             var query = _db.Database.GetCollection<Exhibit>(ResourceType.Exhibit.Name).AsQueryable();
 

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -103,15 +103,15 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             return Ok(summary);
         }
 
-        private async Task<IActionResult> GetVersionAsync<T>(ResourceType type, int id, DateTimeOffset timestamp)
-            where T : ContentBase
-        {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+        //private async Task<IActionResult> GetVersionAsync<T>(ResourceType type, int id, DateTimeOffset timestamp)
+        //    where T : ContentBase
+        //{
+        //    if (!ModelState.IsValid)
+        //        return BadRequest(ModelState);
 
-            // TODO: Validate user permissions
-            var version = await HistoryUtil.GetVersionAsync<T>(_eventStore.EventStream, (type, id), timestamp);
-            return Ok(version);
-        }
+        //    // TODO: Validate user permissions
+        //    var version = await HistoryUtil.GetVersionAsync<T>(_eventStore.EventStream, (type, id), timestamp);
+        //    return Ok(version);
+        //}
     }
 }

--- a/HiP-DataStore/Controllers/HistoryController.cs
+++ b/HiP-DataStore/Controllers/HistoryController.cs
@@ -3,10 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 using PaderbornUniversity.SILab.Hip.DataStore.Core;
 using PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel;
 using PaderbornUniversity.SILab.Hip.DataStore.Model;
-using PaderbornUniversity.SILab.Hip.DataStore.Model.Entity;
 using PaderbornUniversity.SILab.Hip.DataStore.Utility;
 using PaderbornUniversity.SILab.Hip.EventSourcing;
-using System;
 using System.Threading.Tasks;
 
 namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers

--- a/HiP-DataStore/Controllers/QueryHelper.cs
+++ b/HiP-DataStore/Controllers/QueryHelper.cs
@@ -27,10 +27,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 .FilterIf(includedIds != null, x => includedIds.Contains(x.Id));
         }
 
-        public static IQueryable<T> FilterByStatus<T>(this IQueryable<T> query, ContentStatus status, IIdentity User) where T : ContentBase
+        public static IQueryable<T> FilterByStatus<T>(this IQueryable<T> query, ContentStatus status, IIdentity user) where T : ContentBase
         {
             return query.FilterIf(status != ContentStatus.All, x => x.Status == status)
-                        .FilterIf(status == ContentStatus.All && !UserPermissions.IsAllowedToGetDeleted(User),
+                        .FilterIf(status == ContentStatus.All && !UserPermissions.IsAllowedToGetDeleted(user),
                                                                   x => x.Status != ContentStatus.Deleted);
         }
 
@@ -51,11 +51,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 : query.Where(x => x.Timestamp > timestamp.Value);
         }
 
-        public static IQueryable<T> FilterByUser<T>(this IQueryable<T> query, ContentStatus status, IIdentity User) where T : ContentBase
+        public static IQueryable<T> FilterByUser<T>(this IQueryable<T> query, ContentStatus status, IIdentity user) where T : ContentBase
         {
-            bool isAllowedGetAll = UserPermissions.IsAllowedToGetAll(User, status);
+            bool isAllowedGetAll = UserPermissions.IsAllowedToGetAll(user, status);
             return query.FilterIf(!isAllowedGetAll, x =>
-                        ((status == ContentStatus.All) && (x.Status == ContentStatus.Published)) || (x.UserId == User.GetUserIdentity()));
+                        ((status == ContentStatus.All) && (x.Status == ContentStatus.Published)) || (x.UserId == user.GetUserIdentity()));
         }
         /// <summary>
         /// Executes the query to determine the number of results, then retrieves a subset of the results

--- a/HiP-DataStore/Controllers/RoutesController.cs
+++ b/HiP-DataStore/Controllers/RoutesController.cs
@@ -62,10 +62,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            args = args ?? new RouteQueryArgs();
+
             if (args.Status == ContentStatus.Deleted && !UserPermissions.IsAllowedToGetDeleted(User.Identity))
                 return Forbid();
-
-            args = args ?? new RouteQueryArgs();
 
             var query = _db.Database.GetCollection<Route>(ResourceType.Route.Name).AsQueryable();
 

--- a/HiP-DataStore/Core/HistoryUtil.cs
+++ b/HiP-DataStore/Core/HistoryUtil.cs
@@ -38,11 +38,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
                     crudEvent.GetEntityType() == entityId.Type && crudEvent.Id == entityId.Id)
                 {
                     var timestamp = crudEvent.Timestamp;
-                    var user = (crudEvent as IUserActivityEvent).UserId;
+                    var user = (crudEvent as IUserActivityEvent)?.UserId;
 
                     switch (crudEvent)
                     {
-                        case ICreateEvent createEvent:
+                        case ICreateEvent _:
                             if (summary.Created.HasValue)
                             {
                                 // assumption: entity was deleted before and is now recreated (we don't check if there
@@ -56,12 +56,12 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core
                             summary.Changes.Add(new HistorySummary.Change(timestamp, "Created", user));
                             break;
 
-                        case IUpdateEvent updateEvent:
+                        case IUpdateEvent _:
                             summary.LastModified = timestamp;
                             summary.Changes.Add(new HistorySummary.Change(timestamp, "Updated", user));
                             break;
 
-                        case IDeleteEvent deleteEvent:
+                        case IDeleteEvent _:
                             summary.LastModified = timestamp;
                             summary.Deleted = timestamp;
                             summary.Changes.Add(new HistorySummary.Change(timestamp, "Deleted", user));

--- a/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
+++ b/HiP-DataStore/Core/ReadModel/CacheDatabaseManager.cs
@@ -44,8 +44,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.ReadModel
 
             // 2) Subscribe to EventStore to receive all past and future events
             _eventStore = eventStore;
-
-            var subscription = _eventStore.EventStream.SubscribeCatchUp(ApplyEvent);
+            _eventStore.EventStream.SubscribeCatchUp(ApplyEvent);
         }
         
         private void ApplyEvent(IEvent ev)

--- a/HiP-DataStore/Core/WriteModel/EntityIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/EntityIndex.cs
@@ -61,18 +61,18 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         /// <summary>
         /// Gets the IDs of all entities of the given type and status.
         /// </summary>
-        public IReadOnlyCollection<int> AllIds(ResourceType entityType, ContentStatus status, IIdentity User)
+        public IReadOnlyCollection<int> AllIds(ResourceType entityType, ContentStatus status, IIdentity user)
         {
             lock (_lockObject)
             {
-                bool isAllowedGetAll = UserPermissions.IsAllowedToGetAll(User, status);
-                string userId = User.GetUserIdentity();
+                bool isAllowedGetAll = UserPermissions.IsAllowedToGetAll(user, status);
+                string userId = user.GetUserIdentity();
                 var info = GetOrCreateEntityTypeInfo(entityType);
                 return info.Entities
                     .AsQueryable()
                     .FilterIf(!isAllowedGetAll, x =>
                         ((status == ContentStatus.All) && (x.Value.Status == ContentStatus.Published)) || (x.Value.UserId == userId))
-                    .FilterIf(status == ContentStatus.All && !UserPermissions.IsAllowedToGetDeleted(User),
+                    .FilterIf(status == ContentStatus.All && !UserPermissions.IsAllowedToGetDeleted(user),
                                                                   x => x.Value.Status != ContentStatus.Deleted)
                      .Where(x => status == ContentStatus.All || x.Value.Status == status)
                     .Select(x => x.Key)

--- a/HiP-DataStore/Core/WriteModel/EntityIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/EntityIndex.cs
@@ -48,9 +48,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         /// <summary>
         /// Get UserId of an entity owner
         /// </summary>
-        /// <param name="entityType"></param>
-        /// <param name="id"></param>
-        /// <returns></returns>
         public string Owner(ResourceType entityType, int id)
         {
             var info = GetOrCreateEntityTypeInfo(entityType);
@@ -64,9 +61,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         /// <summary>
         /// Gets the IDs of all entities of the given type and status.
         /// </summary>
-        /// <param name="entityType"></param>
-        /// <param name="status"></param>
-        /// <returns></returns>
         public IReadOnlyCollection<int> AllIds(ResourceType entityType, ContentStatus status, IIdentity User)
         {
             lock (_lockObject)

--- a/HiP-DataStore/Utility/EndpointConfig.cs
+++ b/HiP-DataStore/Utility/EndpointConfig.cs
@@ -38,5 +38,12 @@
         /// automatically which might result in an invalid URL.
         /// </summary>
         public string SwaggerEndpoint { get; set; }
+
+        /// <summary>
+        /// URL pattern for generating thumbnail URLs. Should contain a placeholder "{0}" that is replaced with the
+        /// ID of the requested media at runtime. Example:
+        /// "https://docker-hip.cs.upb.de/develop/thumbnailservice/api/Thumbnails?Url=datastore/api/Media/{0}/File"
+        /// </summary>
+        public string ThumbnailUrlPattern { get; set; }
     }
 }

--- a/HiP-DataStore/Utility/EndpointConfig.cs
+++ b/HiP-DataStore/Utility/EndpointConfig.cs
@@ -41,9 +41,13 @@
 
         /// <summary>
         /// URL pattern for generating thumbnail URLs. Should contain a placeholder "{0}" that is replaced with the
-        /// ID of the requested media at runtime. Example:
+        /// ID of the requested media at runtime. The endpoint should support GET and DELETE requests. Example:
         /// "https://docker-hip.cs.upb.de/develop/thumbnailservice/api/Thumbnails?Url=datastore/api/Media/{0}/File"
         /// </summary>
+        /// <remarks>
+        /// This property is optional: If no value is provided, no thumbnail URLs are generated - instead, direct URLs
+        /// to the original image files are then returned.
+        /// </remarks>
         public string ThumbnailUrlPattern { get; set; }
     }
 }

--- a/HiP-DataStore/appsettings.Development.json.example
+++ b/HiP-DataStore/appsettings.Development.json.example
@@ -10,6 +10,7 @@
   "Endpoints": {
     "MongoDbHost": "mongodb://localhost:27017",
     "MongoDbName": "main",
+    "ThumbnailUrlPattern": "https://docker-hip.cs.upb.de/develop/thumbnailservice/api/Thumbnails?Url=datastore/api/Media/{0}/File",
 
     "EventStoreHost": "tcp://localhost:1113",
 


### PR DESCRIPTION
This PR implements support for `HiP-ThumbnailService`:
* The responses of `GET /api/Media` and `GET /api/Media/{id}` now include an additional field `MediaResult.File` which contains...
  * for images: a URL pointing to the thumbnail service. Clients (e.g. mobile app) can append parameters like `&size=medium&mode=uniform` (according to the thumbnail service specification) to get a resized version of the original image.
  * for audio: a URL to DataStore's `/api/Media/{id}/File` from where the audio file can be obtained directly
* A new configuration field `EndpointConfig.ThumbnailUrlPattern` is introduced to specify the URL of the thumbnail service.

### How to test
1. Modify your `appsettings.Development.json` by adding the "ThumbnailUrlPattern"-field according to the example file.
1. Create media and upload an image file for it (via Swagger).
1. Call `GET /api/Media/{id}` (via Swagger) and look for the "File"-field in the response.
1. Call `GET /api/Media` (via Swagger) and look for the "File"-field in the response.
1. Delete the media and observe how this clears the thumbnails in the thumbnail service - the thumbnail service should no longer return any cached images for the deleted media.