### PR TITLE
HIPCMS-794: Added migration to fix AccessRadius for existing exhibits

### DIFF
--- a/HiP-DataStore.Model/Entity/Exhibit.cs
+++ b/HiP-DataStore.Model/Entity/Exhibit.cs
@@ -16,6 +16,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
 
         public float Longitude { get; set; }
 
+        public float AccessRadius { get; set; }
+
         [BsonElement]
         public DocRef<MediaElement> Image { get; private set; } =
             new DocRef<MediaElement>(ResourceType.Media.Name);
@@ -42,6 +44,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Entity
             Status = args.Status;
             Tags.Add(args.Tags?.Select(id => (BsonValue)id));
             Pages.Add(args.Pages?.Select(id => (BsonValue)id));
+            AccessRadius = args.AccessRadius;
         }
     }
 }

--- a/HiP-DataStore.Model/Rest/ExhibitArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitArgs.cs
@@ -30,6 +30,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 
         public List<int> Pages { get; set; }
 
+        public float AccessRadius { get; set; }
+
         public IEnumerable<EntityId> GetReferences()
         {
             if (Image != null)

--- a/HiP-DataStore.Model/Rest/ExhibitArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitArgs.cs
@@ -30,6 +30,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 
         public List<int> Pages { get; set; }
 
+        /// <summary>
+        /// The radius (in km) in which the exhibit can be accessed.
+        /// </summary>
+        [Range(0.001, 1000)]
         public float AccessRadius { get; set; }
 
         public IEnumerable<EntityId> GetReferences()

--- a/HiP-DataStore.Model/Rest/ExhibitQueryArgs.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitQueryArgs.cs
@@ -5,5 +5,9 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
     public class ExhibitQueryArgs : QueryArgs
     {
         public IList<int> OnlyRoutes { get; set; }
+
+        public float? Latitude { get; set; }
+
+        public float? Longitude { get; set; }
     }
 }

--- a/HiP-DataStore.Model/Rest/ExhibitResult.cs
+++ b/HiP-DataStore.Model/Rest/ExhibitResult.cs
@@ -20,6 +20,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 
         public float Longitude { get; set; }
 
+        public float AccessRadius { get; set; }
+
         public bool Used { get; set; }
 
         public string UserId { get; set; }
@@ -46,6 +48,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
             Image = (int?)x.Image.Id;
             Latitude = x.Latitude;
             Longitude = x.Longitude;
+            AccessRadius = x.AccessRadius;
             Used = x.Referencers.Count > 0; // an exhibit is in use if it is contained in (i.e. referenced by) a route
             Pages = x.Pages.Ids.Select(id => (int)id).ToArray();
             Status = x.Status;

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -63,10 +63,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
+            args = args ?? new ExhibitQueryArgs();
+
             if (args.Status == ContentStatus.Deleted && !UserPermissions.IsAllowedToGetDeleted(User.Identity))
                 return Forbid();
-
-            args = args ?? new ExhibitQueryArgs();
 
             var query = _db.Database.GetCollection<Exhibit>(ResourceType.Exhibit.Name).AsQueryable();
 

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -63,10 +63,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            args = args ?? new ExhibitQueryArgs();
-
             if (args.Status == ContentStatus.Deleted && !UserPermissions.IsAllowedToGetDeleted(User.Identity))
                 return Forbid();
+
+            args = args ?? new ExhibitQueryArgs();
 
             var query = _db.Database.GetCollection<Exhibit>(ResourceType.Exhibit.Name).AsQueryable();
 
@@ -76,6 +76,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
 
                 var exhibits = query
                     .FilterByIds(args.Exclude, args.IncludeOnly)
+                    .FilterByLocation(args.Latitude, args.Longitude)
                     .FilterByUser(args.Status,User.Identity)
                     .FilterByStatus(args.Status, User.Identity)
                     .FilterByTimestamp(args.Timestamp)

--- a/HiP-DataStore/Controllers/QueryHelper.cs
+++ b/HiP-DataStore/Controllers/QueryHelper.cs
@@ -28,10 +28,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 .FilterIf(includedIds != null, x => includedIds.Contains(x.Id));
         }
 
-        public static IQueryable<T> FilterByStatus<T>(this IQueryable<T> query, ContentStatus status, IIdentity User) where T : ContentBase
+        public static IQueryable<T> FilterByStatus<T>(this IQueryable<T> query, ContentStatus status, IIdentity user) where T : ContentBase
         {
             return query.FilterIf(status != ContentStatus.All, x => x.Status == status)
-                        .FilterIf(status == ContentStatus.All && !UserPermissions.IsAllowedToGetDeleted(User),
+                        .FilterIf(status == ContentStatus.All && !UserPermissions.IsAllowedToGetDeleted(user),
                                                                   x => x.Status != ContentStatus.Deleted);
         }
 
@@ -52,12 +52,13 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 : query.Where(x => x.Timestamp > timestamp.Value);
         }
 
-        public static IQueryable<T> FilterByUser<T>(this IQueryable<T> query, ContentStatus status, IIdentity User) where T : ContentBase
+        public static IQueryable<T> FilterByUser<T>(this IQueryable<T> query, ContentStatus status, IIdentity user) where T : ContentBase
         {
-            bool isAllowedGetAll = UserPermissions.IsAllowedToGetAll(User, status);
+            bool isAllowedGetAll = UserPermissions.IsAllowedToGetAll(user, status);
             return query.FilterIf(!isAllowedGetAll, x =>
-                        ((status == ContentStatus.All) && (x.Status == ContentStatus.Published)) || (x.UserId == User.GetUserIdentity()));
+                        ((status == ContentStatus.All) && (x.Status == ContentStatus.Published)) || (x.UserId == user.GetUserIdentity()));
         }
+
         /// <summary>
         /// Returns all entries that are located within the radius, defined within the entry itself, around the given latitude and longitude.
         /// If none or only one coordinate is given, all entries are returned.

--- a/HiP-DataStore/Migrations/Migration6AccessRadius.cs
+++ b/HiP-DataStore/Migrations/Migration6AccessRadius.cs
@@ -17,7 +17,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
 
             while (await events.MoveNextAsync())
             {
-                // ReSharper disable once
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
                 if (events.Current is ExhibitCreated exhibitCreated && exhibitCreated.Properties.AccessRadius == 0)
                 {
                     // If AccessRadius is still 0, we assume that this exhibit was created in an earlier version

--- a/HiP-DataStore/Migrations/Migration6AccessRadius.cs
+++ b/HiP-DataStore/Migrations/Migration6AccessRadius.cs
@@ -17,6 +17,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
 
             while (await events.MoveNextAsync())
             {
+                // ReSharper disable once
                 if (events.Current is ExhibitCreated exhibitCreated && exhibitCreated.Properties.AccessRadius == 0)
                 {
                     // If AccessRadius is still 0, we assume that this exhibit was created in an earlier version

--- a/HiP-DataStore/Migrations/Migration6AccessRadius.cs
+++ b/HiP-DataStore/Migrations/Migration6AccessRadius.cs
@@ -1,0 +1,31 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
+{
+    /// <summary>
+    /// Updating to version 6. Version 6 adds the ability to specify an access radius (in km) for an exhibit.
+    /// In prior versions, exhibits don't have this property, so a default value is assigned in this migration.
+    /// </summary>
+    [StreamMigration(from: 5, to: 6)]
+    public class Migration6AccessRadius : IStreamMigration
+    {
+        public async Task MigrateAsync(IStreamMigrationArgs e)
+        {
+            var events = e.GetExistingEvents();
+
+            while (await events.MoveNextAsync())
+            {
+                if (events.Current is ExhibitCreated exhibitCreated && exhibitCreated.Properties.AccessRadius == 0)
+                {
+                    // If AccessRadius is still 0, we assume that this exhibit was created in an earlier version
+                    // of DataStore => thus, we now assign it a default radius of 10 meters
+                    exhibitCreated.Properties.AccessRadius = .01f;
+                }
+
+                e.AppendEvent(events.Current);
+            }
+        }
+    }
+}

--- a/HiP-DataStore/Migrations/Migration7AccessRadius.cs
+++ b/HiP-DataStore/Migrations/Migration7AccessRadius.cs
@@ -1,0 +1,38 @@
+﻿using PaderbornUniversity.SILab.Hip.DataStore.Model.Events;
+using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.DataStore.Migrations
+{
+    /// <summary>
+    /// Updating to version 7. In migration 6 we migrated ExhibitCreated-events to include a default AccessRadius, but
+    /// we forgot to migrate ExhibitUpdated-events, so they still have AccessRadius == 0. This migration fixes that.
+    /// </summary>
+    [StreamMigration(from: 6, to: 7)]
+    public class Migration7AccessRadius : IStreamMigration
+    {
+        public async Task MigrateAsync(IStreamMigrationArgs e)
+        {
+            var events = e.GetExistingEvents();
+            var accessRadius = new Dictionary<int, float>();
+
+            while (await events.MoveNextAsync())
+            {
+                switch (events.Current)
+                {
+                    case ExhibitCreated created: accessRadius[created.Id] = created.Properties.AccessRadius; break;
+                    case ExhibitDeleted deleted: accessRadius.Remove(deleted.Id); break;
+
+                    case ExhibitUpdated updated:
+                        // ReSharper disable once CompareOfFloatsByEqualityOperator
+                        if (updated.Properties.AccessRadius == 0)
+                            updated.Properties.AccessRadius = accessRadius[updated.Id];
+                        break;
+                }
+                
+                e.AppendEvent(events.Current);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is essentially the same as #76, but adds another migration `Migration7AccessRadius` which, together with migration 6, now correctly assigns existing exhibits a default access radius != 0.