### PR TITLE
Increased DataStore SDK version to 2.0.0

### DIFF
--- a/HiP-DataStore.Sdk/HiP-DataStore.Sdk.csproj
+++ b/HiP-DataStore.Sdk/HiP-DataStore.Sdk.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.DataStore</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 

--- a/HiP-DataStore.TypeScript/package/package.json
+++ b/HiP-DataStore.TypeScript/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hip-datastore",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Typescript client for HiP-DataStore",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The public REST API of DataStore has changed since the last NuGet/NPM package version 1.0.1. Here's a summary of the changes (C#):
```diff
public class ExhibitsClient
+    public Task<AllItemsResultOfExhibitResult> GetAsync(IEnumerable<int> onlyRoutes, double? latitude, double? longitude, IEnumerable<int> exclude, IEnumerable<int> includeOnly, int? page, int? pageSize, string orderBy, string query, ContentStatus? status, DateTime? timestamp, CancellationToken cancellationToken)
-    public Task<AllItemsResultOfExhibitResult> GetAsync(IEnumerable<int> onlyRoutes, IEnumerable<int> exclude, IEnumerable<int> includeOnly, int? page, int? pageSize, string orderBy, string query, ContentStatus? status, DateTime? timestamp, CancellationToken cancellationToken)

public enum ContentStatus
+    public const ContentStatus Unpublished - Value: 5

public class QueryArgs
+    public ContentStatus Status { get; set; }
-    public ContentStatus? Status { get; set; }

public class ExhibitResult
+    public double AccessRadius { get; set; }

public class ExhibitArgs
+    public double AccessRadius { get; set; }

public class RatingResult
+    public Dictionary<string, int> RatingTable { get; set; }
```

Since these include breaking changes, the major version must be increased, so we are at v2.0.0.