### PR TITLE
NuGetPack Update (HIPCMS-1052)

### DIFF
--- a/NuGetPack.ps1
+++ b/NuGetPack.ps1
@@ -1,7 +1,6 @@
 $csproj = (ls *.Sdk\*.csproj).FullName
 
 dotnet pack "$csproj" -o . 
+dotnet pack "$csproj" -o . --version-suffix "develop"
 
-$nupkg = (ls *.Sdk\*.nupkg).FullName
-dotnet nuget push "$nupkg" -k "$env:MyGetKey" -s "$env:NuGetFeed"
 $LASTEXITCODE = 0


### PR DESCRIPTION
Updated NuGetPack.ps1, such that it only packs two NuGet packages, where one has a "develop" suffix. 