### PR TITLE
Adding "LastMonthRate" to the rating system

### DIFF
--- a/HiP-DataStore.Model/Rest/RatingResult.cs
+++ b/HiP-DataStore.Model/Rest/RatingResult.cs
@@ -8,8 +8,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Model.Rest
 
         public double Average { get; set; }
 
+        public double LastMonthAverage { get; set; }
+
         public int Count { get; set; }
 
         public Dictionary<int,int> RatingTable { get; set; }
+        
     }
 }

--- a/HiP-DataStore.Sdk/HiP-DataStore.Sdk.csproj
+++ b/HiP-DataStore.Sdk/HiP-DataStore.Sdk.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.DataStore</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -269,27 +269,30 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             }
         }
 
-        [HttpGet("Rating/{id}")]
+        [HttpGet("Rating/{exhibitId}")]
         [ProducesResponseType(typeof(RatingResult), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(403)]
         [ProducesResponseType(404)]
-        public IActionResult GetRating(int id)
+        public IActionResult GetRating(int exhibitId)
         {
 
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            if (!_entityIndex.Exists(ResourceTypes.Exhibit, id))
-                return NotFound(ErrorMessages.ContentNotFound(ResourceTypes.Exhibit, id));
+            if (!_entityIndex.Exists(ResourceTypes.Exhibit, exhibitId))
+                return NotFound(ErrorMessages.ContentNotFound(ResourceTypes.Exhibit, exhibitId));
 
             var result = new RatingResult()
             {
-                Id = id,
-                Average = _ratingIndex.Average(ResourceTypes.Exhibit, id),
-                Count = _ratingIndex.Count(ResourceTypes.Exhibit, id),
-                RatingTable = _ratingIndex.Table(ResourceTypes.Exhibit, id)
+                Id = exhibitId,
+                Average = _ratingIndex.Average(ResourceTypes.Exhibit, exhibitId),
+                LastMonthAverage = _ratingIndex.LastMonthAverage(ResourceTypes.Exhibit, exhibitId),
+                Count = _ratingIndex.Count(ResourceTypes.Exhibit, exhibitId),
+                RatingTable = _ratingIndex.Table(ResourceTypes.Exhibit, exhibitId)
             };
+
+            //in order to fill the property "LastMonthAverage", we have two options, either we query the cached database, or we modify the "RatingIndex" class to include the dates and then query it
 
             return Ok(result);
         }

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -291,9 +291,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 Count = _ratingIndex.Count(ResourceTypes.Exhibit, exhibitId),
                 RatingTable = _ratingIndex.Table(ResourceTypes.Exhibit, exhibitId)
             };
-
-            //in order to fill the property "LastMonthAverage", we have two options, either we query the cached database, or we modify the "RatingIndex" class to include the dates and then query it
-
+                        
             return Ok(result);
         }
 

--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -291,7 +291,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
                 Count = _ratingIndex.Count(ResourceTypes.Exhibit, exhibitId),
                 RatingTable = _ratingIndex.Table(ResourceTypes.Exhibit, exhibitId)
             };
-                        
+
             return Ok(result);
         }
 
@@ -504,6 +504,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             {
                 Id = exhibitId,
                 Average = _ratingIndex.Average(ResourceTypes.QuizQuestion, exhibitId),
+                LastMonthAverage = _ratingIndex.LastMonthAverage(ResourceTypes.QuizQuestion, exhibitId),
                 Count = _ratingIndex.Count(ResourceTypes.QuizQuestion, exhibitId),
                 RatingTable = _ratingIndex.Table(ResourceTypes.QuizQuestion, exhibitId)
             };

--- a/HiP-DataStore/Core/WriteModel/RatingIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/RatingIndex.cs
@@ -120,6 +120,10 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
             return table;
         }
 
+        /// <summary>
+        /// It only calculates the average rating of the specified exhibit for the last month.
+        /// </summary>
+        /// <returns>The last month rating</returns>
         public double CalculateLastMonthAverageRating()
         {
             var nowDate = DateTimeOffset.Now;

--- a/HiP-DataStore/Core/WriteModel/RatingIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/RatingIndex.cs
@@ -19,7 +19,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         {
             return GetOrCreateRatingTypeInfo(res).Ratings.TryGetValue(id, out var t) ? t.NumberRates : 0;
         }
-        public Dictionary<int,int> Table(ResourceType res, int id)
+        public Dictionary<int, int> Table(ResourceType res, int id)
         {
             return GetOrCreateRatingTypeInfo(res).Ratings.TryGetValue(id, out var t) ? t.GetRatingTable() : null;
         }
@@ -29,15 +29,20 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
             return GetOrCreateRatingTypeInfo(res).Ratings.TryGetValue(id, out var t) ? t.GetUserRating(identity.GetUserIdentity()) : 0;
         }
 
-        public double Average(ResourceType res,int id)
+        public double Average(ResourceType res, int id)
         {
             return GetOrCreateRatingTypeInfo(res).Ratings.TryGetValue(id, out var t) ? t.AverageRate : 0;
         }
 
+        public double LastMonthAverage(ResourceType res, int id)
+        {
+            return GetOrCreateRatingTypeInfo(res).Ratings.TryGetValue(id, out var t) ? t.CalculateLastMonthAverageRating() : 0;
+        }
+
         public int NextId(ResourceType entityType)
         {
-             var info = GetOrCreateRatingTypeInfo(entityType);
-             return ++info.MaximumId;            
+            var info = GetOrCreateRatingTypeInfo(entityType);
+            return ++info.MaximumId;
         }
 
         public void ApplyEvent(IEvent e)
@@ -52,7 +57,8 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
                         ratedType.Ratings.Add(ev.EntityId, new RatingEntityInfo());
 
                     var ratedEntity = ratedType.Ratings[ev.EntityId];
-                    ratedEntity.AddRating(ev.UserId, ev.Value);
+                    //ratedEntity.AddRating(ev.UserId, ev.Value);
+                    ratedEntity.AddRating(ev.UserId, ev.Value, ev.Timestamp);
                     break;
             }
         }
@@ -71,60 +77,82 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
     {
         public int MaximumId { get; set; } = -1;
 
+        //the key is the exhibit index, and the value is an object contains the rating info of the specified exhibit
         public Dictionary<int, RatingEntityInfo> Ratings { get; } = new Dictionary<int, RatingEntityInfo>();
 
     }
+
     class RatingEntityInfo
     {
 
-        public double AverageRate { get { return (NumberRates != 0) ? ((double)_sumRate / NumberRates) : 0; }  }
+        public double AverageRate { get { return (NumberRates != 0) ? ((double)_sumRate / NumberRates) : 0; } }
         public int NumberRates { get; private set; }
 
-        // <UserId, Rating>
-        private Dictionary<string, byte> _allRates = new Dictionary<string, byte>();
+        // <UserId, RatingStruct contains the rate value and its date>
+        private Dictionary<string, RatingDateStruct> _allRates = new Dictionary<string, RatingDateStruct>();
         private int _sumRate;
 
-        public void AddRating(string userId, byte rate)
+        public void AddRating(string userId, byte rate, DateTimeOffset rateDate)
         {
             if (_allRates.TryGetValue(userId, out var oldRate))
             {
-                if(CalculateAverageRating(oldRate, rate))
-                    _allRates[userId] = rate;
+                if (CalculateAverageRating(oldRate.Rate, rate))
+                    _allRates[userId] = new RatingDateStruct { Rate = rate, RateDate = rateDate };
             }
             else
             {
-                if(CalculateAverageRating(null, rate))
-                    _allRates.Add(userId, rate);
+                if (CalculateAverageRating(null, rate))
+                    _allRates.Add(userId, new RatingDateStruct { Rate = rate, RateDate = rateDate });
             }
         }
 
         public byte? GetUserRating(string userId)
         {
-            return _allRates.TryGetValue(userId, out var rating) ? (byte?)rating : null;
+            return _allRates.TryGetValue(userId, out var rating) ? (byte?)rating.Rate : null;
         }
 
-        public Dictionary<int,int> GetRatingTable()
+        public Dictionary<int, int> GetRatingTable()
         {
-            Dictionary <int,int> table = new Dictionary <int,int> { {1,0}, {2, 0}, {3, 0}, {4, 0}, {5, 0} };
-            foreach (var rate in _allRates)
+            Dictionary<int, int> table = new Dictionary<int, int> { { 1, 0 }, { 2, 0 }, { 3, 0 }, { 4, 0 }, { 5, 0 } };
+            foreach (var rateStruct in _allRates)
             {
-                table[rate.Value]++;
+                table[rateStruct.Value.Rate]++;
             }
             return table;
         }
+
+        public double CalculateLastMonthAverageRating()
+        {
+            var nowDate = DateTimeOffset.Now;
+            double lastMonthTotalRating = 0, lastMonthAverage = 0;
+            int counter = 0;
+            //iterate through _allRates and calculate the average rating of the last month
+            foreach (var rateStruct in _allRates)
+            {
+                if (rateStruct.Value.RateDate.Month == (nowDate.Month - 1) && rateStruct.Value.RateDate.Year == nowDate.Year)
+                {
+                    counter++;
+                    lastMonthTotalRating += rateStruct.Value.Rate;
+                }
+            }
+            if (counter > 0)
+                lastMonthAverage = lastMonthTotalRating / counter;
+            return lastMonthAverage;
+        }
+
         bool CalculateAverageRating(int? oldRate, int newRate)
         {
             if (!(IsOldRatingValid(oldRate) && CheckRatingRange(newRate)))
                 return false;
 
             if (oldRate != null)
-                  _sumRate += (newRate - oldRate.GetValueOrDefault());
+                _sumRate += (newRate - oldRate.GetValueOrDefault());
             else
             {
                 _sumRate += newRate;
                 NumberRates++;
             }
-            
+
             return true;
         }
         bool IsOldRatingValid(int? oldRate)
@@ -136,5 +164,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
             return (rating >= RatingArgs.MinRateValue && rating <= RatingArgs.MaxRateValue);
         }
 
+    }
+
+    struct RatingDateStruct
+    {
+        public byte Rate;
+        public DateTimeOffset RateDate;
     }
 }

--- a/HiP-DataStore/Core/WriteModel/RatingIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/RatingIndex.cs
@@ -57,7 +57,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
                         ratedType.Ratings.Add(ev.EntityId, new RatingEntityInfo());
 
                     var ratedEntity = ratedType.Ratings[ev.EntityId];
-                    //ratedEntity.AddRating(ev.UserId, ev.Value);
                     ratedEntity.AddRating(ev.UserId, ev.Value, ev.Timestamp);
                     break;
             }
@@ -126,7 +125,6 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
             var nowDate = DateTimeOffset.Now;
             double lastMonthTotalRating = 0, lastMonthAverage = 0;
             int counter = 0;
-            //iterate through _allRates and calculate the average rating of the last month
             foreach (var rateStruct in _allRates)
             {
                 if (rateStruct.Value.RateDate.Month == (nowDate.Month - 1) && rateStruct.Value.RateDate.Year == nowDate.Year)

--- a/HiP-DataStore/Core/WriteModel/RatingIndex.cs
+++ b/HiP-DataStore/Core/WriteModel/RatingIndex.cs
@@ -126,12 +126,11 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
         /// <returns>The last month rating</returns>
         public double CalculateLastMonthAverageRating()
         {
-            var nowDate = DateTimeOffset.Now;
             double lastMonthTotalRating = 0, lastMonthAverage = 0;
             int counter = 0;
             foreach (var rateStruct in _allRates)
             {
-                if (rateStruct.Value.RateDate.Month == (nowDate.Month - 1) && rateStruct.Value.RateDate.Year == nowDate.Year)
+                if (CheckIfRatingIsLastMonthRating(rateStruct.Value.RateDate))
                 {
                     counter++;
                     lastMonthTotalRating += rateStruct.Value.Rate;
@@ -140,6 +139,17 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Core.WriteModel
             if (counter > 0)
                 lastMonthAverage = lastMonthTotalRating / counter;
             return lastMonthAverage;
+        }
+
+        private bool CheckIfRatingIsLastMonthRating(DateTimeOffset ratingDate)
+        {
+            var nowDate = DateTimeOffset.Now;
+            if (nowDate.Month == 1 && ratingDate.Month == 12 && ratingDate.Year == (nowDate.Year - 1))
+                return true;
+            else if (ratingDate.Month == (nowDate.Month - 1) && ratingDate.Year == nowDate.Year)
+                return true;
+            else
+                return false;
         }
 
         bool CalculateAverageRating(int? oldRate, int newRate)


### PR DESCRIPTION
I modified the existing rating system slightly and followed the previous implemented steps, so I queried the in-memory RatingIndex and added the logic to calculate the **average rating** of the specified exhibit for only the **last month** as has been requested by the product owner.
I introduced some modifications into the "RatingIndex" class to store the ratings' dates beside the ratings' values. 