### PR TITLE
Fixed ResourceName in DeleteReview in ExhibitsController

### DIFF
--- a/HiP-DataStore/Controllers/ExhibitsController.cs
+++ b/HiP-DataStore/Controllers/ExhibitsController.cs
@@ -724,7 +724,7 @@ namespace PaderbornUniversity.SILab.Hip.DataStore.Controllers
             if (ReviewHelper.CheckNotFoundGet(id, ResourceTypes.Exhibit, _entityIndex, _reviewIndex) is string errorMessage)
                 return NotFound(errorMessage);
 
-            var reviewId = _reviewIndex.GetReviewId(ResourceTypes.ExhibitPage.Name, id);
+            var reviewId = _reviewIndex.GetReviewId(ResourceTypes.Exhibit.Name, id);
 
             await EntityManager.DeleteEntityAsync(_eventStore, ResourceTypes.Review, reviewId, User.Identity.GetUserIdentity());
             return NoContent();


### PR DESCRIPTION
The wrong ResourceName was used in the DeleteReview method. Looks like a copy/paste mistake to me